### PR TITLE
feat: add monitor deposit address print

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,12 +141,12 @@ async fn get_signers_xonly_key(config: &Settings) -> Result<(), Box<dyn std::err
 }
 
 async fn get_deposit_address(
-    monitored: &Vec<MonitoredDeposit>,
+    monitored: &[MonitoredDeposit],
     args: &GetDepositAddressArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for deposit in monitored {
         let address = Address::from_script(&deposit.to_script_pubkey(), args.network)?;
-        println!("{}:{}", deposit.alias, address);
+        println!("{}: {}", deposit.alias, address);
     }
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/BitcoinL2-Labs/sPoX/issues/10

Adds a `get-deposit-address` CLI command to print the deposit addresses for the monitored deposit in config.

Can be tested in devenv with:
```bash
SPOX_DEPOSIT__DEMO__SIGNERS_XONLY=$(RUST_LOG=info cargo run -- -c src/config/default.toml get-signers-xonly-key) cargo run -- -c src/config/default.toml get-deposit-address -n regtest
```