### PR TITLE
feat: client timeout

### DIFF
--- a/src/bitcoin/node.rs
+++ b/src/bitcoin/node.rs
@@ -1,10 +1,11 @@
 //! Contains client wrappers for bitcoin core
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use bitcoin::ScriptBuf;
-use bitcoincore_rpc::jsonrpc::serde_json;
-use bitcoincore_rpc::{Auth, RpcApi};
+use bitcoincore_rpc::RpcApi;
+use bitcoincore_rpc::jsonrpc::{serde_json, simple_http};
 use bitcoincore_rpc_json::{
     GetChainTipsResultStatus, GetDescriptorInfoResult, ImportDescriptors, ImportMultiResult,
     ListUnspentResultEntry, LoadWalletResult, ScanTxOutRequest, Utxo as RpcUtxo,
@@ -49,21 +50,31 @@ pub struct BitcoinCoreClient {
 
 impl BitcoinCoreClient {
     /// Return a bitcoin-core RPC client from a auth-embedded URL and optional wallet name
-    pub fn from_config(url: &Url, wallet: Option<&str>) -> Result<Self, Error> {
+    pub fn from_config(url: &Url, wallet: Option<&str>, timeout: Duration) -> Result<Self, Error> {
         let username = url.username().to_string();
         let password = url.password().unwrap_or_default().to_string();
         let endpoint = build_endpoint(url, wallet)?;
 
-        Self::new(endpoint.as_str(), username, password)
+        Self::new(endpoint.as_str(), username, password, timeout)
     }
 
     /// Return a bitcoin-core RPC client. Will error if the URL is an invalid URL.
-    pub fn new(url: &str, username: String, password: String) -> Result<Self, Error> {
-        let auth = Auth::UserPass(username, password);
-        let client = bitcoincore_rpc::Client::new(url, auth)
-            .map_err(|err| Error::BitcoinCoreRpcClient(err, url.to_string()))?;
+    pub fn new(
+        url: &str,
+        username: String,
+        password: String,
+        timeout: Duration,
+    ) -> Result<Self, Error> {
+        let transport = simple_http::Builder::new()
+            .url(url)
+            .map_err(|error| Error::BitcoinCoreRpcClient(error, url.to_string()))?
+            .auth(username, Some(password))
+            .timeout(timeout)
+            .build();
 
-        Ok(Self { inner: Arc::new(client) })
+        let client = Arc::new(bitcoincore_rpc::Client::from_jsonrpc(transport.into()));
+
+        Ok(Self { inner: client })
     }
 
     /// Get the canonical chain tip
@@ -92,16 +103,30 @@ impl BitcoinCoreClient {
             .map(|addr| ScanTxOutRequest::Single(format!("raw({})", addr.to_hex_string())))
             .collect::<Vec<_>>();
 
-        let result = self
-            .inner
-            .scan_tx_out_set_blocking(&descriptors)
-            .map_err(Error::BitcoinCoreRpc)?;
+        let result =
+            self.inner
+                .scan_tx_out_set_blocking(&descriptors)
+                .map_err(|error| match error {
+                    bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(
+                        rpc_error,
+                    )) if rpc_error.code == -8 => Error::ScanAlreadyInProgress,
+                    e => Error::BitcoinCoreRpc(e),
+                })?;
 
         if result.success != Some(true) {
             return Err(Error::ScanTxOutFailure);
         }
 
         Ok(result.unspents.into_iter().map(Into::into).collect())
+    }
+
+    /// Return true if a `scantxoutset` scan is already in progress
+    pub fn scan_tx_out_set_scanning(&self) -> Result<bool, Error> {
+        // scantxoutset status returns null when no scan is running
+        self.inner
+            .call("scantxoutset", &["status".into()])
+            .map_err(Error::BitcoinCoreRpc)
+            .map(|res: serde_json::Value| !res.is_null())
     }
 
     /// Get the canonical block hash for a given block height

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -10,6 +10,13 @@ emily_endpoint = "http://127.0.0.1:3031"
 # Environment: SPOX_BITCOIN_RPC_ENDPOINT
 bitcoin_rpc_endpoint = "http://devnet:devnet@127.0.0.1:18443"
 
+# Timeout for the Bitcoin Core RPC client. If configured to use `scantxoutset`,
+# this must be long enough for the RPC to finish the UTXO set scan.
+#
+# Required: false
+# Environment: SPOX_BITCOIN_RPC_TIMEOUT
+# bitcoin_rpc_timeout = 300
+
 # Polling interval in seconds
 #
 # Required: false

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -10,8 +10,10 @@ emily_endpoint = "http://127.0.0.1:3031"
 # Environment: SPOX_BITCOIN_RPC_ENDPOINT
 bitcoin_rpc_endpoint = "http://devnet:devnet@127.0.0.1:18443"
 
-# Timeout for the Bitcoin Core RPC client. If configured to use `scantxoutset`,
-# this must be long enough for the RPC to finish the UTXO set scan.
+# Timeout in seconds for the Bitcoin Core RPC client. Defaults to 300 seconds
+# (5 minutes) because, when no `node_wallet` is configured, spox falls back to
+# `scantxoutset`, which walks the full UTXO set and can take minutes to
+# complete on mainnet.
 #
 # Required: false
 # Environment: SPOX_BITCOIN_RPC_TIMEOUT

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,9 @@ pub struct Settings {
     /// Bitcoin RPC endpoint
     #[serde(deserialize_with = "url_deserializer")]
     pub bitcoin_rpc_endpoint: Url,
+    /// Bitcoin RPC timeout
+    #[serde(deserialize_with = "duration_seconds_deserializer")]
+    pub bitcoin_rpc_timeout: std::time::Duration,
     /// Emily API endpoint
     #[serde(deserialize_with = "url_deserializer")]
     pub emily_endpoint: Url,
@@ -111,6 +114,7 @@ impl Settings {
         let mut cfg_builder = Config::builder();
 
         cfg_builder = cfg_builder.set_default("polling_interval", 30)?;
+        cfg_builder = cfg_builder.set_default("bitcoin_rpc_timeout", 60 * 5)?;
 
         if let Some(path) = config_path {
             cfg_builder = cfg_builder.add_source(File::from(path.as_ref()));
@@ -130,6 +134,11 @@ impl Settings {
     fn validate(&self) -> Result<(), SpoxConfigError> {
         if self.polling_interval.is_zero() {
             return Err(SpoxConfigError::ZeroDurationForbidden("polling_interval"));
+        }
+        if self.bitcoin_rpc_timeout.is_zero() {
+            return Err(SpoxConfigError::ZeroDurationForbidden(
+                "bitcoin_rpc_timeout",
+            ));
         }
 
         if self.registry_contract.is_some() && self.stacks.is_none() {
@@ -199,6 +208,7 @@ mod tests {
             parse_url("http://devnet:devnet@127.0.0.1:18443")
         );
         assert_eq!(settings.polling_interval, Duration::from_secs(30));
+        assert_eq!(settings.bitcoin_rpc_timeout, Duration::from_mins(5));
         assert!(settings.registry_contract.is_none());
     }
 
@@ -227,6 +237,7 @@ mod tests {
     }
 
     #[test_case("polling_interval"; "polling interval")]
+    #[test_case("bitcoin_rpc_timeout"; "bitcoin rpc timeout")]
     fn zero_values_for_nonzero_fields_fail_in_config(field: &str) {
         clear_env();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,6 +28,7 @@ impl TryFrom<&Settings> for Context {
         let bitcoin_client = BitcoinCoreClient::from_config(
             &value.bitcoin_rpc_endpoint,
             value.node_wallet.as_ref().map(|w| w.name.as_str()),
+            value.bitcoin_rpc_timeout,
         )?;
         let emily_config = EmilyConfig {
             base_path: value

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -93,7 +93,7 @@ impl DepositMonitor {
         if self.context.settings().node_wallet.is_none() {
             if bitcoin.scan_tx_out_set_scanning()? {
                 tracing::warn!(
-                    "scan already in progress, attempting a new one will fail; skipping fetching UTXOs"
+                    "scan already in progress, attempting a new one will fail; skipping fetching utxos"
                 );
                 return Err(Error::ScanAlreadyInProgress);
             }

--- a/src/deposit_monitor.rs
+++ b/src/deposit_monitor.rs
@@ -91,8 +91,23 @@ impl DepositMonitor {
     ) -> Result<Vec<Utxo>, Error> {
         let bitcoin = self.context.bitcoin_client();
         if self.context.settings().node_wallet.is_none() {
+            if bitcoin.scan_tx_out_set_scanning()? {
+                tracing::warn!(
+                    "scan already in progress, attempting a new one will fail; skipping fetching UTXOs"
+                );
+                return Err(Error::ScanAlreadyInProgress);
+            }
+
             // TODO: batch the scan_tx_out_set call
-            return bitcoin.scan_tx_out_set(script_pubkeys);
+            return bitcoin
+                .scan_tx_out_set(script_pubkeys)
+                .inspect_err(|error| {
+                    if matches!(error, Error::ScanAlreadyInProgress) {
+                        tracing::warn!(
+                            "scan didn't finish in time, consider increasing the rpc timeout"
+                        )
+                    }
+                });
         }
 
         let watched_script_pubkeys: HashSet<&ScriptBuf> = script_pubkeys.iter().collect();

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use bitcoin::ScriptBuf;
+use bitcoincore_rpc::jsonrpc;
 
 /// Top-level application error
 #[derive(Debug, thiserror::Error)]
@@ -13,7 +14,7 @@ pub enum Error {
 
     /// Error when creating an RPC client to bitcoin-core
     #[error("could not create RPC client to {1}: {0}")]
-    BitcoinCoreRpcClient(#[source] bitcoincore_rpc::Error, String),
+    BitcoinCoreRpcClient(#[source] jsonrpc::http::simple_http::Error, String),
 
     /// Could not serialize the clarity value to bytes.
     ///
@@ -89,6 +90,10 @@ pub enum Error {
     /// sBTC error
     #[error(transparent)]
     Sbtc(#[from] sbtc::error::Error),
+
+    /// Scan already in progress
+    #[error("scan already in progress")]
+    ScanAlreadyInProgress,
 
     /// A call to `scantxoutset` failed
     #[error("a call to `scantxoutset` failed")]


### PR DESCRIPTION
Closes https://github.com/stx-labs/sPoX/issues/31

Add a `bitcoin_rpc_timeout` parameter to increase the Bitcoin core RPC client timeout. We need this on mainnet as `scantxoutset` can take a couple of minutes.

Also add better logs around scan already in progress.

## Testing Information

Add config test, and tested with the devenv demo and on private mainnet.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code