### PR TITLE
feat: add CI release job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitmodules
+.gitworktrees
+
+node_modules
+target
+
+contracts
+tests
+webapp

--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -1,0 +1,54 @@
+FROM --platform=$BUILDPLATFORM rust:1.94.1-slim-trixie AS build
+
+ARG TARGETARCH
+
+# Install build dependencies.
+# clang/libclang-dev: needed by bindgen (used by p256k1).
+# Cross-compilers for both target architectures.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+    libclang-dev \
+    git \
+    pkg-config \
+    g++ \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    gcc-x86-64-linux-gnu \
+    g++-x86-64-linux-gnu \
+    findutils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Add the Rust target for the target architecture.
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        rustup target add aarch64-unknown-linux-gnu; \
+    else \
+        rustup target add x86_64-unknown-linux-gnu; \
+    fi
+
+WORKDIR /code/spox
+COPY . .
+
+# Build the binary, cross-compiling for the target architecture.
+RUN export LIBCLANG_PATH="$(find /usr/lib/llvm-* -name lib -type d | head -n 1)" && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        export TARGET="aarch64-unknown-linux-gnu" && \
+        export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc && \
+        export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ && \
+        export AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar && \
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
+    else \
+        export TARGET="x86_64-unknown-linux-gnu" && \
+        export CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc && \
+        export CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++ && \
+        export AR_x86_64_unknown_linux_gnu=x86_64-linux-gnu-ar && \
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc; \
+    fi && \
+    cargo build --target "$TARGET" --bin spox --release --locked && \
+    mkdir -p /output && \
+    cp "target/$TARGET/release/spox" /output/spox
+
+FROM debian:trixie-slim AS spox
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /output/spox /usr/local/bin/spox
+
+ENTRYPOINT ["/usr/local/bin/spox"]

--- a/.github/workflows/create-tags.yaml
+++ b/.github/workflows/create-tags.yaml
@@ -56,7 +56,7 @@ jobs:
             if (!semverRegex.test(tag)) {
               core.setFailed(`Error: Invalid tag format: "${tag}". Expected SemVer like X.Y.Z, vX.Y.Z-note, or X.Y.Z+note`);
             } else {
-              github.rest.git.createRef({
+              await github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: `refs/tags/${tag}`,

--- a/.github/workflows/create-tags.yaml
+++ b/.github/workflows/create-tags.yaml
@@ -1,0 +1,85 @@
+name: Manual Tag and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag Name (e.g., v1.0.0)"
+        required: true
+      release:
+        type: choice
+        description: "Trigger Release?"
+        required: true
+        options:
+        - no
+        - yes
+
+permissions:
+  contents: write # Needed to create a tag
+  actions: write # Needed to trigger another workflow via API
+
+jobs:
+  log_tag:
+    name: Print Tag Info
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.set_output.outputs.tag_name }}
+    steps:
+      - name: Show Tag Name
+        id: print_name
+        run: |
+          printf "Tag to be created: ${{ inputs.tag_name }}"
+
+      - name: Set Output
+        id: set_output
+        run: |
+          printf "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+
+  create_tag:
+    name: Create Tag
+    runs-on: ubuntu-latest
+    environment: Tags
+    needs: log_tag
+    steps:
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@ed353a33594a2fa97ea6702d838e4a935cce374d
+
+      - name: Create Tag
+        id: create_tag
+        uses: stacks-sbtc/actions/github-script@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          script: |
+            const tag = "${{ inputs.tag_name }}";
+            const semverRegex = /^v?\d+\.\d+\.\d+(-[\w.-]+)?(\+[\w.-]+)?$/;
+            
+            if (!semverRegex.test(tag)) {
+              core.setFailed(`Error: Invalid tag format: "${tag}". Expected SemVer like X.Y.Z, vX.Y.Z-note, or X.Y.Z+note`);
+            } else {
+              github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `refs/tags/${tag}`,
+                sha: context.sha
+              });
+            }
+
+  trigger_release:
+    name: Trigger Release
+    runs-on: ubuntu-latest
+    needs: create_tag
+    if: ${{ inputs.release == 'true' }}
+    steps:
+      - name: Trigger Release Workflow
+        id: trigger_release
+        uses: stacks-sbtc/actions/github-script@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          script: |
+            const response = await github.request('POST /repos/{owner}/{repo}/dispatches', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'image_build_and_draft_release',
+              client_payload: {
+                tag_name: '${{ inputs.tag_name }}' // Pass the input value
+              }
+            });

--- a/.github/workflows/image-build-and-draft-release.yaml
+++ b/.github/workflows/image-build-and-draft-release.yaml
@@ -1,0 +1,121 @@
+## Github workflow to build a multiarch docker image from pre-built binaries
+
+name: GHCR Release Image (Binary)
+
+on:
+  repository_dispatch:
+    types: [image_build_and_draft_release]
+
+permissions:
+  id-token: write
+  contents: write
+  attestations: write
+  packages: write
+
+## Define which docker arch to build for
+env:
+  docker_platforms: "linux/amd64,linux/arm64"
+  latest_release: $(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+
+concurrency:
+  group: docker-image-${{ github.head_ref || github.ref || github.run_id }}
+  ## Always cancel duplicate jobs
+  cancel-in-progress: true
+
+run-name: "Build and Release spox ${{ github.event.client_payload.tag_name }} Docker Image"
+
+jobs:
+  image:
+    name: Build Image
+    outputs:
+      spox: ${{ steps.save_digest.outputs.spox }}
+    runs-on: ubuntu-latest
+    environment: "Publish to GHCR"
+    steps:
+      - name: Log in to GHCR
+        id: ghcr_login
+        uses: stacks-sbtc/actions/docker/login-action@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      ## Checkout the branch of the release provided.
+      ## This requires that a release branch exists for the tag.
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          ref: refs/tags/${{ github.event.client_payload.tag_name }}
+
+      - name: Setup Buildx
+        id: setup_buildx
+        uses: stacks-sbtc/actions/docker/setup-buildx-action@ed353a33594a2fa97ea6702d838e4a935cce374d
+
+      ## if the repo owner is not `stacks-network`, default to a docker-org of the repo owner (i.e. github user id)
+      ## this allows forks to run the docker push workflows without having to hardcode a dockerhub org (but it does require docker hub user to match github username)
+      - name: Set Local env vars
+        id: set_env
+        if: |
+          github.repository_owner != 'stacks-network'
+        run: |
+          echo "ghcr_org=ghcr.io/${{ github.repository_owner }}" >> "$GITHUB_ENV"
+
+      ## Set docker metatdata
+      - name: Docker Metadata
+        id: docker_metadata
+        uses: stacks-sbtc/actions/docker/metadata-action@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          images: |
+            ${{ env.ghcr_org }}/spox
+          tags: |
+            type=raw,value=${{ github.event.client_payload.tag_name }}
+            type=raw,value=latest,enable=${{ env.latest_release == github.event.client_payload.tag_name }}
+
+      ## Build docker image for release
+      - name: Build and Push
+        id: docker_build
+        uses: stacks-sbtc/actions/docker/build-push-action@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          file: ./.github/actions/Dockerfile
+          platforms: ${{ env.docker_platforms }}
+          tags: ${{ steps.docker_metadata.outputs.tags }}
+          labels: ${{ steps.docker_metadata.outputs.labels }}
+          target: spox
+          push: true
+
+      - name: Save digest as output
+        id: save_digest
+        run: echo "spox=${{ steps.docker_build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        id: generate_attestation
+        uses: stacks-sbtc/actions/attest-build-provenance@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          subject-name: ${{ env.ghcr_org }}/spox
+          subject-digest: ${{ steps.docker_build.outputs.digest }}
+
+      - name: Download artifact attestation
+        id: download_attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh attestation download oci://${{ env.ghcr_org }}/spox:${{ github.event.client_payload.tag_name }} -R ${{ github.repository_owner }}/spox
+          
+          # Rename the attestation bundle (replace ":" with "_")
+          ATTESTATION_FILE="$(echo "${{ steps.docker_build.outputs.digest }}.jsonl" | tr ':' '_')"
+          mv "${{ steps.docker_build.outputs.digest }}.jsonl" "$ATTESTATION_FILE"
+          echo "ATTESTATION_FILE=$ATTESTATION_FILE" >> $GITHUB_ENV
+          
+          # Generate trusted root
+          gh attestation trusted-root > trusted_root.jsonl
+
+      - name: Upload Attestation Files as Artifacts
+        id: upload_attestation
+        uses: stacks-sbtc/actions/upload-artifact@ed353a33594a2fa97ea6702d838e4a935cce374d
+        with:
+          name: attestation-files-${{ github.event.client_payload.tag_name }}
+          overwrite: true
+          path: |
+            ${{ env.ATTESTATION_FILE }}
+            trusted_root.jsonl

--- a/.github/workflows/image-build-and-draft-release.yaml
+++ b/.github/workflows/image-build-and-draft-release.yaml
@@ -1,4 +1,4 @@
-## Github workflow to build a multiarch docker image from pre-built binaries
+## GitHub workflow to build a multiarch Docker image
 
 name: GHCR Release Image (Binary)
 
@@ -52,12 +52,10 @@ jobs:
         id: setup_buildx
         uses: stacks-sbtc/actions/docker/setup-buildx-action@ed353a33594a2fa97ea6702d838e4a935cce374d
 
-      ## if the repo owner is not `stacks-network`, default to a docker-org of the repo owner (i.e. github user id)
+      ## default to a docker-org of the repo owner (i.e. github user id)
       ## this allows forks to run the docker push workflows without having to hardcode a dockerhub org (but it does require docker hub user to match github username)
       - name: Set Local env vars
         id: set_env
-        if: |
-          github.repository_owner != 'stacks-network'
         run: |
           echo "ghcr_org=ghcr.io/${{ github.repository_owner }}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Port over the release job and Docker file from sBTC. I remove the create release notes bit for now, we can eventually add it later.

We need to create the two GH environments (and relative authorizations).

## Testing Information

Built both versions locally, and tested one with the test flow in the README with something like:
```
# docker.toml is like default.toml but with host.docker.internal instead of 127.0.0.1

SPOX_DEPOSIT__DEMO__SIGNERS_XONLY=$(docker run --rm --volume $PWD/src/config/docker.toml:/spox.toml -e RUST_LOG=info spox:local -c /spox.toml get-signers-xonly-key)

docker run --rm --volume $PWD/src/config/docker.toml:/spox.toml -e SPOX_DEPOSIT__DEMO__SIGNERS_XONLY=$SPOX_DEPOSIT__DEMO__SIGNERS_XONLY spox:local -c /spox.toml get-deposit-address -n regtest

# Send a BTC payment to the above address

docker run --rm --volume $PWD/src/config/docker.toml:/spox.toml -e SPOX_DEPOSIT__DEMO__SIGNERS_XONLY=$SPOX_DEPOSIT__DEMO__SIGNERS_XONLY spox:local -c /spox.toml
```

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code