### PR TITLE
feat: add functionality for fetching pending claims from registry

### DIFF
--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -474,10 +474,10 @@
 ;; linked list from cursor, or from the head when cursor is none, and
 ;; returns up to 100 rows where remaining-cycles is greater than zero and
 ;; next-claim-distribution is less than the current distribution cycle.
-;; Paginate by passing the last row's staker and signer-manager as the next
-;; cursor. Note that a short page does not mean the tail was reached,
-;; callers that need all claims must resume from a known key until an empty
-;; list is returned.
+;; Non-pending registrations still consume walk ticks without appending a
+;; row, so a short or empty `rows` list does not mean the tail was reached.
+;; Use the returned `next` cursor: none means the walk hit the tail; some key
+;; means pass that key as the next `cursor` to resume after it.
 ;;
 ;; Parameters:
 ;;   cursor  none to start at the head, or the `next` key from the previous

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -474,10 +474,10 @@
 ;; linked list from cursor, or from the head when cursor is none, and
 ;; returns up to 100 rows where remaining-cycles is greater than zero and
 ;; next-claim-distribution is less than the current distribution cycle.
-;; Non-pending registrations still consume walk ticks without appending a
-;; row, so a short or empty `rows` list does not mean the tail was reached.
-;; Use the returned `next` cursor: none means the walk hit the tail; some key
-;; means pass that key as the next `cursor` to resume after it.
+;; Paginate by passing the last row's staker and signer-manager as the next
+;; cursor. Note that a short page does not mean the tail was reached,
+;; callers that need all claims must resume from a known key until an empty
+;; list is returned.
 ;;
 ;; Parameters:
 ;;   cursor  none to start at the head, or the `next` key from the previous

--- a/src/stacks/clarity.rs
+++ b/src/stacks/clarity.rs
@@ -1,0 +1,68 @@
+//! Helper utilities for dealing with data returned from Clarity smart
+//! contracts.
+
+use std::collections::BTreeMap;
+
+use clarity::vm::ClarityName;
+use clarity::vm::Value as ClarityValue;
+use clarity::vm::types::OptionalData;
+use clarity::vm::types::PrincipalData;
+use clarity::vm::types::SequenceData;
+use clarity::vm::types::TupleData;
+
+use crate::error::Error;
+
+/// A struct in a Clarity smart contract, which they call a tuple.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClarityTuple(BTreeMap<ClarityName, ClarityValue>);
+
+impl ClarityTuple {
+    /// Create a new ClarityMap from a BTreeMap of ClarityName to ClarityValue.
+    pub fn new(data_map: BTreeMap<ClarityName, ClarityValue>) -> Self {
+        Self(data_map)
+    }
+
+    /// Extract the buff value from the given field
+    pub fn remove_buff(&mut self, field: &'static str) -> Result<Vec<u8>, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Sequence(SequenceData::Buffer(buf))) => Ok(buf.data),
+            _ => Err(Error::ClarityMissingTupleEntry(field)),
+        }
+    }
+
+    /// Extract the option value from the given field
+    pub fn remove_option(&mut self, field: &'static str) -> Result<Option<ClarityValue>, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Optional(OptionalData { data })) => Ok(data.map(|x| *x)),
+            _ => Err(Error::ClarityMissingTupleEntry(field)),
+        }
+    }
+
+    /// Extract the principal value from the given field
+    pub fn remove_principal(&mut self, field: &'static str) -> Result<PrincipalData, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Principal(data)) => Ok(data),
+            _ => Err(Error::ClarityMissingTupleEntry(field)),
+        }
+    }
+
+    /// Extract the u128 value from the given field
+    pub fn remove_uint(&mut self, field: &'static str) -> Result<u128, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::UInt(data)) => Ok(data),
+            _ => Err(Error::ClarityMissingTupleEntry(field)),
+        }
+    }
+}
+
+impl TryFrom<ClarityValue> for ClarityTuple {
+    type Error = Error;
+
+    fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
+        let ClarityValue::Tuple(TupleData { data_map, .. }) = value else {
+            return Err(Error::InvalidStacksResponse("did not get a tuple"));
+        };
+
+        Ok(ClarityTuple::new(data_map))
+    }
+}

--- a/src/stacks/clarity.rs
+++ b/src/stacks/clarity.rs
@@ -17,7 +17,7 @@ use crate::error::Error;
 pub struct ClarityTuple(BTreeMap<ClarityName, ClarityValue>);
 
 impl ClarityTuple {
-    /// Create a new ClarityMap from a BTreeMap of ClarityName to ClarityValue.
+    /// Create a new ClarityTuple from a BTreeMap of ClarityName to ClarityValue.
     pub fn new(data_map: BTreeMap<ClarityName, ClarityValue>) -> Self {
         Self(data_map)
     }

--- a/src/stacks/clarity.rs
+++ b/src/stacks/clarity.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use clarity::vm::ClarityName;
 use clarity::vm::Value as ClarityValue;
+use clarity::vm::types::ListData;
 use clarity::vm::types::OptionalData;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::types::SequenceData;
@@ -26,6 +27,14 @@ impl ClarityTuple {
     pub fn remove_buff(&mut self, field: &'static str) -> Result<Vec<u8>, Error> {
         match self.0.remove(field) {
             Some(ClarityValue::Sequence(SequenceData::Buffer(buf))) => Ok(buf.data),
+            _ => Err(Error::ClarityMissingTupleEntry(field)),
+        }
+    }
+
+    /// Extract the list value from the given field
+    pub fn remove_list(&mut self, field: &'static str) -> Result<Vec<ClarityValue>, Error> {
+        match self.0.remove(field) {
+            Some(ClarityValue::Sequence(SequenceData::List(ListData { data, .. }))) => Ok(data),
             _ => Err(Error::ClarityMissingTupleEntry(field)),
         }
     }

--- a/src/stacks/mod.rs
+++ b/src/stacks/mod.rs
@@ -3,3 +3,4 @@
 pub mod clarity;
 pub mod node;
 pub mod registry;
+pub mod reward_claim_registry;

--- a/src/stacks/mod.rs
+++ b/src/stacks/mod.rs
@@ -1,4 +1,5 @@
 //! Contains functionality for interacting with the Stacks blockchain
 
+pub mod clarity;
 pub mod node;
 pub mod registry;

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -3,7 +3,7 @@
 use bitcoin::ScriptBuf;
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::types::{
-    ListData, ListTypeData , QualifiedContractIdentifier, SequenceData, TupleData,
+    ListData, ListTypeData, QualifiedContractIdentifier, SequenceData, TupleData,
 };
 use clarity::vm::{ClarityName, ContractName, Value};
 use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
@@ -182,8 +182,8 @@ impl TryFrom<RawRegisteredDeposit> for MonitoredDeposit {
 mod tests {
     use bitcoin::{NetworkKind, PrivateKey, PublicKey, secp256k1::SECP256K1};
     use bitcoincore_rpc::jsonrpc::serde_json;
-    use clarity::{types::StacksEpochId, vm::types::PrincipalData};
     use clarity::vm::types::OptionalData;
+    use clarity::{types::StacksEpochId, vm::types::PrincipalData};
 
     use super::*;
 

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -1,16 +1,15 @@
 //! Client for the on-chain deposit address registry.
 
-use std::collections::BTreeMap;
-
 use bitcoin::ScriptBuf;
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::types::{
-    ListData, ListTypeData, OptionalData, QualifiedContractIdentifier, SequenceData, TupleData,
+    ListData, ListTypeData , QualifiedContractIdentifier, SequenceData, TupleData,
 };
 use clarity::vm::{ClarityName, ContractName, Value};
 use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
 
 use crate::error::Error;
+use crate::stacks::clarity::ClarityTuple;
 use crate::stacks::node::StacksClient;
 use crate::storage::model::{MonitoredDeposit, MonitoredDepositSource};
 
@@ -129,12 +128,14 @@ impl DepositAddressRegistry {
 impl TryFrom<Value> for RawRegisteredDepositScripts {
     type Error = Error;
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        let Value::Tuple(TupleData { mut data_map, .. }) = value else {
+        let Value::Tuple(TupleData { data_map, .. }) = value else {
             return Err(Error::InvalidStacksResponse("did not get an address tuple"));
         };
 
-        let deposit_script = tuple_remove_buff(&mut data_map, "deposit-script")?;
-        let reclaim_script = tuple_remove_buff(&mut data_map, "reclaim-script")?;
+        let mut clarity_map = ClarityTuple::new(data_map);
+
+        let deposit_script = clarity_map.remove_buff("deposit-script")?;
+        let reclaim_script = clarity_map.remove_buff("reclaim-script")?;
         Ok(RawRegisteredDepositScripts { deposit_script, reclaim_script })
     }
 }
@@ -142,13 +143,12 @@ impl TryFrom<Value> for RawRegisteredDepositScripts {
 impl TryFrom<Value> for RawRegisteredDeposit {
     type Error = Error;
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        let Value::Tuple(TupleData { mut data_map, .. }) = value else {
-            return Err(Error::InvalidStacksResponse("did not get a tuple"));
-        };
+        let mut clarity_map = ClarityTuple::try_from(value)?;
 
-        let id = tuple_remove_uint(&mut data_map, "id")?;
-        let address = tuple_remove_option(&mut data_map, "address")?
-            .map(|value| RawRegisteredDepositScripts::try_from(*value))
+        let id = clarity_map.remove_uint("id")?;
+        let address = clarity_map
+            .remove_option("address")?
+            .map(RawRegisteredDepositScripts::try_from)
             .transpose()?;
 
         Ok(RawRegisteredDeposit {
@@ -178,41 +178,12 @@ impl TryFrom<RawRegisteredDeposit> for MonitoredDeposit {
     }
 }
 
-fn tuple_remove_uint(
-    data_map: &mut BTreeMap<ClarityName, Value>,
-    field: &'static str,
-) -> Result<u128, Error> {
-    match data_map.remove(field) {
-        Some(Value::UInt(data)) => Ok(data),
-        _ => Err(Error::ClarityMissingTupleEntry(field)),
-    }
-}
-
-fn tuple_remove_option(
-    data_map: &mut BTreeMap<ClarityName, Value>,
-    field: &'static str,
-) -> Result<Option<Box<Value>>, Error> {
-    match data_map.remove(field) {
-        Some(Value::Optional(OptionalData { data })) => Ok(data),
-        _ => Err(Error::ClarityMissingTupleEntry(field)),
-    }
-}
-
-fn tuple_remove_buff(
-    data_map: &mut BTreeMap<ClarityName, Value>,
-    field: &'static str,
-) -> Result<Vec<u8>, Error> {
-    match data_map.remove(field) {
-        Some(Value::Sequence(SequenceData::Buffer(buf))) => Ok(buf.data),
-        _ => Err(Error::ClarityMissingTupleEntry(field)),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use bitcoin::{NetworkKind, PrivateKey, PublicKey, secp256k1::SECP256K1};
     use bitcoincore_rpc::jsonrpc::serde_json;
     use clarity::{types::StacksEpochId, vm::types::PrincipalData};
+    use clarity::vm::types::OptionalData;
 
     use super::*;
 

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -4,10 +4,8 @@ use clarity::types::chainstate::StacksAddress;
 use clarity::vm::ClarityName;
 use clarity::vm::ContractName;
 use clarity::vm::Value as ClarityValue;
-use clarity::vm::types::ListData;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::types::QualifiedContractIdentifier;
-use clarity::vm::types::SequenceData;
 use clarity::vm::types::TupleData;
 
 use crate::error::Error;
@@ -37,13 +35,26 @@ pub struct PendingClaim {
 }
 
 impl PendingClaim {
-    /// Registration key for this claim row (used as a pagination cursor).
+    /// Registration key for this claim row.
     pub fn registration_key(&self) -> RegistrationKey {
         RegistrationKey {
             staker: self.staker.clone(),
             signer_manager: self.signer_manager.clone(),
         }
     }
+}
+
+/// One page from `get-pending-claims`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingClaimsPage {
+    /// Pending claim rows found during this bounded walk.
+    pub claims: Vec<PendingClaim>,
+    /// Cursor to pass to the next `get_pending_claims` call.
+    ///
+    /// `None` means the walk reached the tail of the registration list.
+    /// `Some` is the last visited registration key, which may not be a
+    /// pending claim itself.
+    pub next: Option<RegistrationKey>,
 }
 
 /// Client for querying the on-chain reward claim registry contract.
@@ -72,17 +83,13 @@ impl RewardClaimRegistry {
     /// Fetch a page of pending claims from the registry.
     ///
     /// Pass `None` for `cursor` to start at the head of the registration
-    /// linked list. To paginate, pass the last row's `RegistrationKey` from
-    /// the previous page so the walk resumes at that key's successor.
-    ///
-    /// An empty page does not by itself mean the linked list is exhausted:
-    /// non-pending registrations still consume walk ticks. Callers that need
-    /// every pending claim should keep resuming from the last returned key
-    /// (see [`Self::get_all_pending_claims`]).
+    /// linked list. To paginate, pass [`PendingClaimsPage::next`] from the
+    /// previous page. `next == None` means the walk reached the tail; an
+    /// empty `claims` list alone does not.
     pub async fn get_pending_claims(
         &self,
         cursor: Option<&RegistrationKey>,
-    ) -> Result<Vec<PendingClaim>, Error> {
+    ) -> Result<PendingClaimsPage, Error> {
         let cursor_arg = match cursor {
             Some(key) => {
                 let tuple = TupleData::from_data(vec![
@@ -118,33 +125,39 @@ impl RewardClaimRegistry {
             return Err(Error::InvalidStacksResponse("expected a response"));
         };
 
-        let ClarityValue::Sequence(SequenceData::List(ListData { data, .. })) = *response.data
-        else {
-            return Err(Error::InvalidStacksResponse("did not get a list"));
-        };
-
-        data.into_iter().map(PendingClaim::try_from).collect()
+        PendingClaimsPage::try_from(*response.data)
     }
 
     /// Fetch every pending claim by paging through `get-pending-claims`.
     ///
-    /// Starts at the head and keeps calling with the last returned row's
-    /// registration key until a page comes back empty after that key has been
-    /// sent as the cursor (or the first page is empty).
+    /// Continues while the page's `next` cursor is `Some`, including pages
+    /// that return no rows (ticks spent on non-pending registrations).
     pub async fn get_all_pending_claims(&self) -> Result<Vec<PendingClaim>, Error> {
         let mut all = Vec::new();
         let mut cursor: Option<RegistrationKey> = None;
 
         loop {
             let page = self.get_pending_claims(cursor.as_ref()).await?;
-            let Some(last) = page.last() else {
-                break;
-            };
-            cursor = Some(last.registration_key());
-            all.extend(page);
+            all.extend(page.claims);
+            match page.next {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
         }
 
         Ok(all)
+    }
+}
+
+impl TryFrom<ClarityValue> for RegistrationKey {
+    type Error = Error;
+
+    fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
+        let mut clarity_map = ClarityTuple::try_from(value)?;
+        Ok(RegistrationKey {
+            staker: clarity_map.remove_principal("staker")?,
+            signer_manager: clarity_map.remove_principal("signer-manager")?,
+        })
     }
 }
 
@@ -171,6 +184,27 @@ impl TryFrom<ClarityValue> for PendingClaim {
     }
 }
 
+impl TryFrom<ClarityValue> for PendingClaimsPage {
+    type Error = Error;
+
+    fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
+        let mut clarity_map = ClarityTuple::try_from(value)?;
+
+        let claims = clarity_map
+            .remove_list("rows")?
+            .into_iter()
+            .map(PendingClaim::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let next = clarity_map
+            .remove_option("next")?
+            .map(RegistrationKey::try_from)
+            .transpose()?;
+
+        Ok(PendingClaimsPage { claims, next })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bitcoincore_rpc::jsonrpc::serde_json;
@@ -182,7 +216,7 @@ mod tests {
         fn from(value: &PendingClaim) -> Self {
             let bond_index = value
                 .bond_index
-                .map(|index| Box::new(ClarityValue::UInt(index as u128)));
+                .map(|index| Box::new(ClarityValue::UInt(index)));
             let tuple_entries = vec![
                 (
                     ClarityName::from("signer-manager"),
@@ -198,7 +232,7 @@ mod tests {
                 ),
                 (
                     ClarityName::from("reward-cycle"),
-                    ClarityValue::UInt(value.reward_cycle as u128),
+                    ClarityValue::UInt(value.reward_cycle),
                 ),
             ];
             ClarityValue::Tuple(TupleData::from_data(tuple_entries).unwrap())
@@ -221,9 +255,23 @@ mod tests {
         }
     }
 
-    fn ok_list(claims: &[PendingClaim]) -> ClarityValue {
+    fn ok_page(claims: &[PendingClaim], next: Option<&RegistrationKey>) -> ClarityValue {
         let rows: Vec<ClarityValue> = claims.iter().map(ClarityValue::from).collect();
-        ClarityValue::okay(ClarityValue::cons_list_unsanitized(rows).unwrap()).unwrap()
+        let next_value = match next {
+            Some(key) => ClarityValue::some(ClarityValue::from(key)).unwrap(),
+            None => ClarityValue::none(),
+        };
+        let page = ClarityValue::Tuple(
+            TupleData::from_data(vec![
+                (
+                    ClarityName::from("rows"),
+                    ClarityValue::cons_list_unsanitized(rows).unwrap(),
+                ),
+                (ClarityName::from("next"), next_value),
+            ])
+            .unwrap(),
+        );
+        ClarityValue::okay(page).unwrap()
     }
 
     #[tokio::test]
@@ -239,10 +287,13 @@ mod tests {
             bond_index: None,
             reward_cycle: 42,
         };
+        let next = claim.registration_key();
 
         let raw_json_response = format!(
             r#"{{"okay": true, "result":"0x{}"}}"#,
-            ok_list(&[claim.clone()]).serialize_to_hex().unwrap(),
+            ok_page(&[claim.clone()], Some(&next))
+                .serialize_to_hex()
+                .unwrap(),
         );
 
         let mut stacks_node_server = mockito::Server::new_async().await;
@@ -273,7 +324,13 @@ mod tests {
 
         let result = registry.get_pending_claims(None).await.unwrap();
 
-        assert_eq!(result, vec![claim]);
+        assert_eq!(
+            result,
+            PendingClaimsPage {
+                claims: vec![claim],
+                next: Some(next),
+            }
+        );
         mock.assert();
     }
 
@@ -303,7 +360,7 @@ mod tests {
 
         let raw_json_response = format!(
             r#"{{"okay": true, "result":"0x{}"}}"#,
-            ok_list(&[claim.clone()]).serialize_to_hex().unwrap(),
+            ok_page(&[claim.clone()], None).serialize_to_hex().unwrap(),
         );
 
         let mut stacks_node_server = mockito::Server::new_async().await;
@@ -334,15 +391,21 @@ mod tests {
 
         let result = registry.get_pending_claims(Some(&cursor)).await.unwrap();
 
-        assert_eq!(result, vec![claim]);
+        assert_eq!(
+            result,
+            PendingClaimsPage {
+                claims: vec![claim],
+                next: None,
+            }
+        );
         mock.assert();
     }
 
     #[tokio::test]
-    async fn get_pending_claims_empty_page() {
+    async fn get_pending_claims_empty_page_at_tail() {
         let raw_json_response = format!(
             r#"{{"okay": true, "result":"0x{}"}}"#,
-            ok_list(&[]).serialize_to_hex().unwrap(),
+            ok_page(&[], None).serialize_to_hex().unwrap(),
         );
 
         let mut stacks_node_server = mockito::Server::new_async().await;
@@ -370,31 +433,35 @@ mod tests {
 
         let result = registry.get_pending_claims(None).await.unwrap();
 
-        assert!(result.is_empty());
+        assert_eq!(
+            result,
+            PendingClaimsPage {
+                claims: vec![],
+                next: None,
+            }
+        );
         mock.assert();
     }
 
     #[tokio::test]
-    async fn get_all_pending_claims_pages_until_empty() {
+    async fn get_all_pending_claims_continues_on_empty_rows_with_next() {
         let signer_manager =
             PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
                 .unwrap();
 
-        let first = PendingClaim {
-            signer_manager: signer_manager.clone(),
+        // First page: ticks burned on non-pending nodes, resume cursor only.
+        let skipped = RegistrationKey {
             staker: PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap(),
-            bond_index: None,
-            reward_cycle: 42,
+            signer_manager: signer_manager.clone(),
         };
-        let second = PendingClaim {
+        let pending = PendingClaim {
             signer_manager: signer_manager.clone(),
             staker: PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap(),
             bond_index: Some(7),
             reward_cycle: 99,
         };
 
-        let cursor = first.registration_key();
-        let cursor_hex = ClarityValue::some(ClarityValue::from(&cursor))
+        let skipped_hex = ClarityValue::some(ClarityValue::from(&skipped))
             .unwrap()
             .serialize_to_hex()
             .unwrap();
@@ -402,7 +469,7 @@ mod tests {
         let mut stacks_node_server = mockito::Server::new_async().await;
         let path = "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest";
 
-        let first_page = stacks_node_server
+        let empty_with_next = stacks_node_server
             .mock("POST", path)
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [ClarityValue::none().serialize_to_hex().unwrap()]
@@ -411,41 +478,21 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(format!(
                 r#"{{"okay": true, "result":"0x{}"}}"#,
-                ok_list(&[first.clone()]).serialize_to_hex().unwrap(),
+                ok_page(&[], Some(&skipped)).serialize_to_hex().unwrap(),
             ))
             .expect(1)
             .create();
 
-        let second_page = stacks_node_server
+        let pending_then_done = stacks_node_server
             .mock("POST", path)
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "arguments": [cursor_hex]
+                "arguments": [skipped_hex]
             })))
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(format!(
                 r#"{{"okay": true, "result":"0x{}"}}"#,
-                ok_list(&[second.clone()]).serialize_to_hex().unwrap(),
-            ))
-            .expect(1)
-            .create();
-
-        let second_cursor = second.registration_key();
-        let second_cursor_hex = ClarityValue::some(ClarityValue::from(&second_cursor))
-            .unwrap()
-            .serialize_to_hex()
-            .unwrap();
-
-        let empty_page = stacks_node_server
-            .mock("POST", path)
-            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
-                "arguments": [second_cursor_hex]
-            })))
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(format!(
-                r#"{{"okay": true, "result":"0x{}"}}"#,
-                ok_list(&[]).serialize_to_hex().unwrap(),
+                ok_page(&[pending.clone()], None).serialize_to_hex().unwrap(),
             ))
             .expect(1)
             .create();
@@ -463,9 +510,8 @@ mod tests {
 
         let result = registry.get_all_pending_claims().await.unwrap();
 
-        assert_eq!(result, vec![first, second]);
-        first_page.assert();
-        second_page.assert();
-        empty_page.assert();
+        assert_eq!(result, vec![pending]);
+        empty_with_next.assert();
+        pending_then_done.assert();
     }
 }

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -36,6 +36,16 @@ pub struct PendingClaim {
     pub reward_cycle: u128,
 }
 
+impl PendingClaim {
+    /// Registration key for this claim row (used as a pagination cursor).
+    pub fn registration_key(&self) -> RegistrationKey {
+        RegistrationKey {
+            staker: self.staker.clone(),
+            signer_manager: self.signer_manager.clone(),
+        }
+    }
+}
+
 /// Client for querying the on-chain reward claim registry contract.
 #[derive(Debug, Clone)]
 pub struct RewardClaimRegistry {
@@ -62,8 +72,13 @@ impl RewardClaimRegistry {
     /// Fetch a page of pending claims from the registry.
     ///
     /// Pass `None` for `cursor` to start at the head of the registration
-    /// linked list. To paginate, pass the last row's
-    /// `RegistrationKey` from the previous page.
+    /// linked list. To paginate, pass the last row's `RegistrationKey` from
+    /// the previous page so the walk resumes at that key's successor.
+    ///
+    /// An empty page does not by itself mean the linked list is exhausted:
+    /// non-pending registrations still consume walk ticks. Callers that need
+    /// every pending claim should keep resuming from the last returned key
+    /// (see [`Self::get_all_pending_claims`]).
     pub async fn get_pending_claims(
         &self,
         cursor: Option<&RegistrationKey>,
@@ -109,6 +124,27 @@ impl RewardClaimRegistry {
         };
 
         data.into_iter().map(PendingClaim::try_from).collect()
+    }
+
+    /// Fetch every pending claim by paging through `get-pending-claims`.
+    ///
+    /// Starts at the head and keeps calling with the last returned row's
+    /// registration key until a page comes back empty after that key has been
+    /// sent as the cursor (or the first page is empty).
+    pub async fn get_all_pending_claims(&self) -> Result<Vec<PendingClaim>, Error> {
+        let mut all = Vec::new();
+        let mut cursor: Option<RegistrationKey> = None;
+
+        loop {
+            let page = self.get_pending_claims(cursor.as_ref()).await?;
+            let Some(last) = page.last() else {
+                break;
+            };
+            cursor = Some(last.registration_key());
+            all.extend(page);
+        }
+
+        Ok(all)
     }
 }
 
@@ -336,5 +372,100 @@ mod tests {
 
         assert!(result.is_empty());
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_all_pending_claims_pages_until_empty() {
+        let signer_manager =
+            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
+                .unwrap();
+
+        let first = PendingClaim {
+            signer_manager: signer_manager.clone(),
+            staker: PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap(),
+            bond_index: None,
+            reward_cycle: 42,
+        };
+        let second = PendingClaim {
+            signer_manager: signer_manager.clone(),
+            staker: PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap(),
+            bond_index: Some(7),
+            reward_cycle: 99,
+        };
+
+        let cursor = first.registration_key();
+        let cursor_hex = ClarityValue::some(ClarityValue::from(&cursor))
+            .unwrap()
+            .serialize_to_hex()
+            .unwrap();
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let path = "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest";
+
+        let first_page = stacks_node_server
+            .mock("POST", path)
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "arguments": [ClarityValue::none().serialize_to_hex().unwrap()]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"okay": true, "result":"0x{}"}}"#,
+                ok_list(&[first.clone()]).serialize_to_hex().unwrap(),
+            ))
+            .expect(1)
+            .create();
+
+        let second_page = stacks_node_server
+            .mock("POST", path)
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "arguments": [cursor_hex]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"okay": true, "result":"0x{}"}}"#,
+                ok_list(&[second.clone()]).serialize_to_hex().unwrap(),
+            ))
+            .expect(1)
+            .create();
+
+        let second_cursor = second.registration_key();
+        let second_cursor_hex = ClarityValue::some(ClarityValue::from(&second_cursor))
+            .unwrap()
+            .serialize_to_hex()
+            .unwrap();
+
+        let empty_page = stacks_node_server
+            .mock("POST", path)
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "arguments": [second_cursor_hex]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"okay": true, "result":"0x{}"}}"#,
+                ok_list(&[]).serialize_to_hex().unwrap(),
+            ))
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url).unwrap();
+
+        let registry = RewardClaimRegistry::new(
+            QualifiedContractIdentifier::parse(
+                "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claim-registry",
+            )
+            .unwrap(),
+            client,
+        );
+
+        let result = registry.get_all_pending_claims().await.unwrap();
+
+        assert_eq!(result, vec![first, second]);
+        first_page.assert();
+        second_page.assert();
+        empty_page.assert();
     }
 }

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -1,0 +1,340 @@
+//! Client for the on-chain reward claim registry.
+
+use clarity::types::chainstate::StacksAddress;
+use clarity::vm::ClarityName;
+use clarity::vm::ContractName;
+use clarity::vm::Value as ClarityValue;
+use clarity::vm::types::ListData;
+use clarity::vm::types::PrincipalData;
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::types::SequenceData;
+use clarity::vm::types::TupleData;
+
+use crate::error::Error;
+use crate::stacks::clarity::ClarityTuple;
+use crate::stacks::node::StacksClient;
+
+/// Key identifying a registration in the reward claim registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrationKey {
+    /// The staker principal on the registration.
+    pub staker: PrincipalData,
+    /// The signer-manager principal on the registration.
+    pub signer_manager: PrincipalData,
+}
+
+/// A single pending claim row from `get-pending-claims`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingClaim {
+    /// The signer-manager principal for this registration.
+    pub signer_manager: PrincipalData,
+    /// The staker principal for this registration.
+    pub staker: PrincipalData,
+    /// Bond index when the staker is in a bond; `None` for STX-only stakes.
+    pub bond_index: Option<u128>,
+    /// The pox-5 reward cycle to claim.
+    pub reward_cycle: u128,
+}
+
+/// Client for querying the on-chain reward claim registry contract.
+#[derive(Debug, Clone)]
+pub struct RewardClaimRegistry {
+    /// The deployer of the registry smart contract.
+    contract_principal: StacksAddress,
+    /// The name of the registry smart contract.
+    contract_name: ContractName,
+    /// The client used to make the requests.
+    client: StacksClient,
+}
+
+impl RewardClaimRegistry {
+    /// Create a new reward claim registry client.
+    pub fn new(contract: QualifiedContractIdentifier, client: StacksClient) -> Self {
+        let contract_principal = contract.issuer.into();
+
+        Self {
+            contract_name: contract.name,
+            contract_principal,
+            client,
+        }
+    }
+
+    /// Fetch a page of pending claims from the registry.
+    ///
+    /// Pass `None` for `cursor` to start at the head of the registration
+    /// linked list. To paginate, pass the last row's
+    /// `RegistrationKey` from the previous page.
+    pub async fn get_pending_claims(
+        &self,
+        cursor: Option<&RegistrationKey>,
+    ) -> Result<Vec<PendingClaim>, Error> {
+        let cursor_arg = match cursor {
+            Some(key) => {
+                let tuple = TupleData::from_data(vec![
+                    (
+                        ClarityName::from("staker"),
+                        ClarityValue::Principal(key.staker.clone()),
+                    ),
+                    (
+                        ClarityName::from("signer-manager"),
+                        ClarityValue::Principal(key.signer_manager.clone()),
+                    ),
+                ])
+                .map_err(|_| Error::InvalidStacksResponse("could not construct cursor tuple"))?;
+                ClarityValue::some(ClarityValue::Tuple(tuple)).map_err(|_| {
+                    Error::InvalidStacksResponse("could not construct cursor option")
+                })?
+            }
+            None => ClarityValue::none(),
+        };
+
+        let result = self
+            .client
+            .call_read(
+                &self.contract_principal,
+                &self.contract_name,
+                &ClarityName::from("get-pending-claims"),
+                &self.contract_principal,
+                &[cursor_arg],
+            )
+            .await?;
+
+        let ClarityValue::Response(response) = result else {
+            return Err(Error::InvalidStacksResponse("expected a response"));
+        };
+
+        let ClarityValue::Sequence(SequenceData::List(ListData { data, .. })) = *response.data
+        else {
+            return Err(Error::InvalidStacksResponse("did not get a list"));
+        };
+
+        data.into_iter().map(PendingClaim::try_from).collect()
+    }
+}
+
+impl TryFrom<ClarityValue> for PendingClaim {
+    type Error = Error;
+
+    fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
+        let mut clarity_map = ClarityTuple::try_from(value)?;
+
+        let bond_index = clarity_map
+            .remove_option("bond-index")?
+            .map(|value| match value {
+                ClarityValue::UInt(index) => Ok(index),
+                _ => Err(Error::InvalidStacksResponse("bond-index was not a uint")),
+            })
+            .transpose()?;
+
+        Ok(PendingClaim {
+            signer_manager: clarity_map.remove_principal("signer-manager")?,
+            staker: clarity_map.remove_principal("staker")?,
+            bond_index,
+            reward_cycle: clarity_map.remove_uint("reward-cycle")?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoincore_rpc::jsonrpc::serde_json;
+    use clarity::vm::types::OptionalData;
+
+    use super::*;
+
+    impl From<&PendingClaim> for ClarityValue {
+        fn from(value: &PendingClaim) -> Self {
+            let bond_index = value
+                .bond_index
+                .map(|index| Box::new(ClarityValue::UInt(index as u128)));
+            let tuple_entries = vec![
+                (
+                    ClarityName::from("signer-manager"),
+                    ClarityValue::Principal(value.signer_manager.clone()),
+                ),
+                (
+                    ClarityName::from("staker"),
+                    ClarityValue::Principal(value.staker.clone()),
+                ),
+                (
+                    ClarityName::from("bond-index"),
+                    ClarityValue::Optional(OptionalData { data: bond_index }),
+                ),
+                (
+                    ClarityName::from("reward-cycle"),
+                    ClarityValue::UInt(value.reward_cycle as u128),
+                ),
+            ];
+            ClarityValue::Tuple(TupleData::from_data(tuple_entries).unwrap())
+        }
+    }
+
+    impl From<&RegistrationKey> for ClarityValue {
+        fn from(value: &RegistrationKey) -> Self {
+            let tuple_entries = vec![
+                (
+                    ClarityName::from("staker"),
+                    ClarityValue::Principal(value.staker.clone()),
+                ),
+                (
+                    ClarityName::from("signer-manager"),
+                    ClarityValue::Principal(value.signer_manager.clone()),
+                ),
+            ];
+            ClarityValue::Tuple(TupleData::from_data(tuple_entries).unwrap())
+        }
+    }
+
+    fn ok_list(claims: &[PendingClaim]) -> ClarityValue {
+        let rows: Vec<ClarityValue> = claims.iter().map(ClarityValue::from).collect();
+        ClarityValue::okay(ClarityValue::cons_list_unsanitized(rows).unwrap()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn get_pending_claims_works_without_cursor() {
+        let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
+        let signer_manager =
+            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
+                .unwrap();
+
+        let claim = PendingClaim {
+            signer_manager: signer_manager.clone(),
+            staker: staker.clone(),
+            bond_index: None,
+            reward_cycle: 42,
+        };
+
+        let raw_json_response = format!(
+            r#"{{"okay": true, "result":"0x{}"}}"#,
+            ok_list(&[claim.clone()]).serialize_to_hex().unwrap(),
+        );
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock(
+                "POST",
+                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
+            )
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "arguments": [ClarityValue::none().serialize_to_hex().unwrap()]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url).unwrap();
+
+        let registry = RewardClaimRegistry::new(
+            QualifiedContractIdentifier::parse(
+                "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claim-registry",
+            )
+            .unwrap(),
+            client,
+        );
+
+        let result = registry.get_pending_claims(None).await.unwrap();
+
+        assert_eq!(result, vec![claim]);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_pending_claims_works_with_cursor() {
+        let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
+        let signer_manager =
+            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
+                .unwrap();
+
+        let cursor = RegistrationKey {
+            staker: staker.clone(),
+            signer_manager: signer_manager.clone(),
+        };
+
+        let claim = PendingClaim {
+            signer_manager,
+            staker: PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap(),
+            bond_index: Some(7),
+            reward_cycle: 99,
+        };
+
+        let cursor_hex = ClarityValue::some(ClarityValue::from(&cursor))
+            .unwrap()
+            .serialize_to_hex()
+            .unwrap();
+
+        let raw_json_response = format!(
+            r#"{{"okay": true, "result":"0x{}"}}"#,
+            ok_list(&[claim.clone()]).serialize_to_hex().unwrap(),
+        );
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock(
+                "POST",
+                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
+            )
+            .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+                "arguments": [cursor_hex]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url).unwrap();
+
+        let registry = RewardClaimRegistry::new(
+            QualifiedContractIdentifier::parse(
+                "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claim-registry",
+            )
+            .unwrap(),
+            client,
+        );
+
+        let result = registry.get_pending_claims(Some(&cursor)).await.unwrap();
+
+        assert_eq!(result, vec![claim]);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_pending_claims_empty_page() {
+        let raw_json_response = format!(
+            r#"{{"okay": true, "result":"0x{}"}}"#,
+            ok_list(&[]).serialize_to_hex().unwrap(),
+        );
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock(
+                "POST",
+                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url).unwrap();
+
+        let registry = RewardClaimRegistry::new(
+            QualifiedContractIdentifier::parse(
+                "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claim-registry",
+            )
+            .unwrap(),
+            client,
+        );
+
+        let result = registry.get_pending_claims(None).await.unwrap();
+
+        assert!(result.is_empty());
+        mock.assert();
+    }
+}

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -433,13 +433,7 @@ mod tests {
 
         let result = registry.get_pending_claims(None).await.unwrap();
 
-        assert_eq!(
-            result,
-            PendingClaimsPage {
-                claims: vec![],
-                next: None,
-            }
-        );
+        assert_eq!(result, PendingClaimsPage { claims: vec![], next: None });
         mock.assert();
     }
 
@@ -492,7 +486,9 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(format!(
                 r#"{{"okay": true, "result":"0x{}"}}"#,
-                ok_page(&[pending.clone()], None).serialize_to_hex().unwrap(),
+                ok_page(&[pending.clone()], None)
+                    .serialize_to_hex()
+                    .unwrap(),
             ))
             .expect(1)
             .create();


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/39

## Changes

* Add Rust code for making the `get-pending-claims` read-only call and getting all claims, assuming no transactions update the smart contract state. The main functions are `get_all_pending_claims` and `get_pending_claims`.
* Tidied up the code for extracting fields from a Clarity tuple.

## Testing Information

I wanted to add integration tests using Clarinet, but it appears that there is a bug at pox-5 activation (https://github.com/stx-labs/clarinet/issues/2488), so that was a no-go for now.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
