### PR TITLE
feat: add plumbing for stacks transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if 1.0.1",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +226,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -265,6 +283,12 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -338,6 +362,7 @@ dependencies = [
  "integer-sqrt",
  "lazy_static",
  "regex",
+ "rusqlite",
  "serde",
  "serde_derive",
  "serde_json",
@@ -353,8 +378,10 @@ source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790
 dependencies = [
  "lazy_static",
  "regex",
+ "rusqlite",
  "serde",
  "serde_derive",
+ "serde_json",
  "slog",
  "stacks-common",
 ]
@@ -465,7 +492,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -568,7 +595,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "dirs-sys-next",
 ]
 
@@ -580,7 +607,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -682,6 +709,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +768,22 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
@@ -786,7 +841,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -799,7 +854,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
  "r-efi",
@@ -845,6 +900,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
@@ -853,6 +917,15 @@ dependencies = [
  "equivalent",
  "foldhash",
  "serde",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1194,6 +1267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,7 +1315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.1",
  "combine",
  "jni-sys 0.3.1",
  "log",
@@ -1312,6 +1394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,7 +1421,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -1383,6 +1475,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libstackerdb"
+version = "0.0.1"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+dependencies = [
+ "clarity",
+ "serde",
+ "sha2 0.10.9",
+ "stacks-common",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1573,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1457,6 +1599,18 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -1481,6 +1635,30 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if 1.0.1",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1567,6 +1745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1764,16 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pox-locking"
+version = "2.4.0"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+dependencies = [
+ "clarity",
+ "slog",
+ "stacks-common",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1865,7 +2059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.1",
  "getrandom 0.2.16",
  "libc",
  "untrusted",
@@ -1879,6 +2073,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "serde_json",
+ "smallvec",
 ]
 
 [[package]]
@@ -2101,7 +2310,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2156,14 +2365,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2257,7 +2467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -2269,7 +2479,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
  "sha2-asm",
@@ -2333,6 +2543,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -2410,7 +2626,10 @@ dependencies = [
  "mockito",
  "reqwest",
  "sbtc",
+ "secp256k1 0.29.1",
  "serde",
+ "serde_json",
+ "stackslib",
  "test-case",
  "testing-emily-client",
  "thiserror 2.0.18",
@@ -2433,7 +2652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.1",
  "libc",
  "psm",
  "windows-sys 0.59.0",
@@ -2450,8 +2669,11 @@ dependencies = [
  "hashbrown 0.15.4",
  "lazy_static",
  "libsecp256k1",
+ "nix",
  "p256",
+ "rand 0.8.6",
  "ripemd",
+ "rusqlite",
  "secp256k1 0.24.3",
  "serde",
  "serde_derive",
@@ -2462,6 +2684,39 @@ dependencies = [
  "slog-term",
  "thiserror 1.0.69",
  "toml 0.5.11",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "stackslib"
+version = "0.0.1"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+dependencies = [
+ "clarity",
+ "ed25519-dalek",
+ "lazy_static",
+ "libstackerdb",
+ "mio 0.6.23",
+ "nix",
+ "percent-encoding",
+ "pox-locking",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "regex",
+ "ripemd",
+ "rusqlite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.9",
+ "siphasher",
+ "slog",
+ "stacks-common",
+ "time",
+ "toml 0.5.11",
+ "url",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2515,7 +2770,7 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2533,7 +2788,7 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2610,7 +2865,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -2677,7 +2932,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -2780,7 +3035,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2921,6 +3176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,7 +3227,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -2992,7 +3253,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.1",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -3062,6 +3323,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3069,6 +3336,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3328,7 +3601,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3336,6 +3609,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "yoke"
@@ -3440,3 +3723,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ sbtc = { git = "https://github.com/stacks-sbtc/sbtc.git", rev = "b2865dd9e63fb14
 emily-client = { git = "https://github.com/stacks-sbtc/sbtc.git", rev = "b2865dd9e63fb143c6b427c0c4a013233a52f283", default-features = false }
 
 clarity = { git = "https://github.com/stacks-network/stacks-core", rev = "1cba695b09690790b1220b0f5d149f70f78ddea5", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core", rev = "1cba695b09690790b1220b0f5d149f70f78ddea5", default-features = false }
 
 bitcoin = { version = "0.32.8", default-features = false, features = ["serde", "rand-std"] }
 bitcoincore-rpc = { version = "0.19.0", default-features = false }
@@ -19,7 +20,9 @@ bitcoincore-rpc-json = { version = "0.19.0", default-features = false }
 clap = { version = "4.6.1", default-features = false, features = ["derive", "env", "std", "help"] }
 config = { version = "0.15.22", default-features = false, features = ["toml"] }
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
+secp256k1 = { version = "0.29.1", default-features = false, features = ["std", "global-context", "recovery", "serde"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.145", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.18", default-features = false }
 tokio = { version = "1.52.1", default-features = false, features = ["signal", "macros", "rt-multi-thread", "rt"] }
 tracing = { version = "0.1.44", default-features = false, features = ["attributes"]}

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -25,13 +25,6 @@ bitcoin_rpc_endpoint = "http://devnet:devnet@127.0.0.1:18443"
 # Environment: SPOX_POLLING_INTERVAL
 # polling_interval = 30
 
-# Run the reward-claim / settlement process on new Bitcoin tips.
-# When enabled, `[stacks]` must include a `private_key`.
-#
-# Required: false
-# Environment: SPOX_REWARD_CLAIMS_ENABLED
-# reward_claims_enabled = false
-
 # Registry smart contract
 #
 # Required: false
@@ -89,27 +82,37 @@ reclaim_script = "75206c44dfe47941b0271c642c549d9a763afce7c6b0495c72f1a32c2f0989
 # !! ===========================================================================
 # !! Stacks configuration
 # !! ---------------------------------------------------------------------------
-# !! This stanza is required only to run some CLI commands, otherwise can be
-# !! omitted.
+# !! This stanza is required for some CLI commands, registry reads, and when
+# !! `[reward_claims]` is present. Otherwise it can be omitted.
 # !! ===========================================================================
 [stacks]
 # Stacks rpc endpoint
-# Required when `reward_claims_enabled = true`.
 #
-# Required: false
+# Required: true (when this stanza is present)
 # Environment: SPOX_STACKS__RPC_ENDPOINT
 rpc_endpoint = "http://127.0.0.1:20443"
 
 # The address of the deployer of the sBTC smart contracts.
-# Required when `reward_claims_enabled = true`.
 #
-# Required: false
+# Required: true (when this stanza is present)
 # Environment: SPOX_STACKS__SBTC_DEPLOYER
 sbtc_deployer = "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS"
 
-# Hex-encoded 32-byte secp256k1 private key used to sign Stacks transactions.
-# Required when `reward_claims_enabled = true`.
+# !! ===========================================================================
+# !! Reward claims configuration
+# !! ---------------------------------------------------------------------------
+# !! Presence of this stanza enables the reward-claim / settlement process.
+# !! Requires `[stacks]` as well.
+# !! ===========================================================================
+# [reward_claims]
+# Fully-qualified principal for the reward-claim-registry.
 #
-# Required: false
-# Environment: SPOX_STACKS__PRIVATE_KEY
-# private_key = "0000000000000000000000000000000000000000000000000000000000000001"
+# Required: true (when this stanza is present)
+# Environment: SPOX_REWARD_CLAIMS__CLAIMS_CONTRACT
+# claims_contract = "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claim-registry"
+
+# Hex-encoded 32-byte secp256k1 private key used to sign Stacks transactions.
+#
+# Required: true (when this stanza is present)
+# Environment: SPOX_REWARD_CLAIMS__PRIVATE_KEY
+# private_key = "a000000000000000000000000000000000000000000000000000000000000001"

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -97,3 +97,9 @@ rpc_endpoint = "http://127.0.0.1:20443"
 # Required: true
 # Environment: SPOX_STACKS__SBTC_DEPLOYER
 sbtc_deployer = "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS"
+
+# Hex-encoded 32-byte secp256k1 private key used to sign Stacks transactions.
+#
+# Required: true
+# Environment: SPOX_STACKS__PRIVATE_KEY
+private_key = "0000000000000000000000000000000000000000000000000000000000000001"

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -25,6 +25,13 @@ bitcoin_rpc_endpoint = "http://devnet:devnet@127.0.0.1:18443"
 # Environment: SPOX_POLLING_INTERVAL
 # polling_interval = 30
 
+# Run the reward-claim / settlement process on new Bitcoin tips.
+# When enabled, `[stacks]` must include a `private_key`.
+#
+# Required: false
+# Environment: SPOX_REWARD_CLAIMS_ENABLED
+# reward_claims_enabled = false
+
 # Registry smart contract
 #
 # Required: false
@@ -87,19 +94,22 @@ reclaim_script = "75206c44dfe47941b0271c642c549d9a763afce7c6b0495c72f1a32c2f0989
 # !! ===========================================================================
 [stacks]
 # Stacks rpc endpoint
+# Required when `reward_claims_enabled = true`.
 #
-# Required: true
+# Required: false
 # Environment: SPOX_STACKS__RPC_ENDPOINT
 rpc_endpoint = "http://127.0.0.1:20443"
 
 # The address of the deployer of the sBTC smart contracts.
+# Required when `reward_claims_enabled = true`.
 #
-# Required: true
+# Required: false
 # Environment: SPOX_STACKS__SBTC_DEPLOYER
 sbtc_deployer = "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS"
 
 # Hex-encoded 32-byte secp256k1 private key used to sign Stacks transactions.
+# Required when `reward_claims_enabled = true`.
 #
-# Required: true
+# Required: false
 # Environment: SPOX_STACKS__PRIVATE_KEY
-private_key = "0000000000000000000000000000000000000000000000000000000000000001"
+# private_key = "0000000000000000000000000000000000000000000000000000000000000001"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -63,6 +63,11 @@ pub struct Settings {
     /// Registry smart contract address
     #[serde(default, deserialize_with = "contract_deserializer_option")]
     pub registry_contract: Option<QualifiedContractIdentifier>,
+    /// Whether reward-claim / settlement processing is enabled.
+    ///
+    /// When enabled, `[stacks]` must be present.
+    #[serde(default)]
+    pub reward_claims_enabled: bool,
     /// Stacks config, used only for some CLI commands and for the registry contract
     pub stacks: Option<StacksConfig>,
     /// Bitcoin core wallet config
@@ -80,6 +85,9 @@ pub struct StacksConfig {
     pub sbtc_deployer: StacksAddress,
     /// Hex-encoded 32-byte secp256k1 private key used to sign Stacks
     /// transactions.
+    ///
+    /// Required when [`Settings::reward_claims_enabled`] is true.
+    /// Environment: `SPOX_STACKS__PRIVATE_KEY`
     pub private_key: SecretKey,
 }
 
@@ -149,6 +157,12 @@ impl Settings {
             return Err(SpoxConfigError::MissingStacksConfig);
         }
 
+        if self.reward_claims_enabled {
+            if self.stacks.is_none() {
+                return Err(SpoxConfigError::MissingStacksConfig);
+            };
+        }
+
         if let Some(ref wallet) = self.node_wallet
             && wallet.name.trim().is_empty()
         {
@@ -214,6 +228,8 @@ mod tests {
         assert_eq!(settings.polling_interval, Duration::from_secs(30));
         assert_eq!(settings.bitcoin_rpc_timeout, Duration::from_mins(5));
         assert!(settings.registry_contract.is_none());
+        assert!(!settings.reward_claims_enabled);
+        settings.stacks.as_ref().unwrap();
     }
 
     #[test]
@@ -321,5 +337,21 @@ mod tests {
             Settings::new_from_default_config(),
             Err(SpoxConfigError::EmptyBitcoinWalletName)
         ));
+    }
+
+    #[test]
+    fn reward_claims_enabled_with_private_key_succeeds() {
+        clear_env();
+
+        set_var("SPOX_REWARD_CLAIMS_ENABLED", "true");
+        // Include a hex letter so Environment::try_parsing leaves this as a string.
+        set_var(
+            "SPOX_STACKS__PRIVATE_KEY",
+            "a000000000000000000000000000000000000000000000000000000000000001",
+        );
+
+        let settings = Settings::new_from_default_config().unwrap();
+        assert!(settings.reward_claims_enabled);
+        settings.stacks.unwrap();
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -121,15 +121,9 @@ impl Settings {
     /// The environment variables are prefixed with `SPOX_` and the nested
     /// fields are separated with double underscores.
     pub fn new(config_path: Option<impl AsRef<Path>>) -> Result<Self, SpoxConfigError> {
-        // To properly parse lists from both environment and config files while
-        // using a custom deserializer, we need to specify the list separator,
-        // enable try_parsing and specify the keys which should be parsed as lists.
-        // If the keys aren't specified, the deserializer will try to parse all
-        // Strings as lists which will result in an error.
         let env = Environment::with_prefix(CONFIG_PREFIX)
             .prefix_separator("_")
-            .separator("__")
-            .try_parsing(true);
+            .separator("__");
 
         let mut cfg_builder = Config::builder();
 
@@ -376,10 +370,10 @@ mod tests {
             "SPOX_REWARD_CLAIMS__CLAIMS_CONTRACT",
             "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claims",
         );
-        // Include a hex letter so Environment::try_parsing leaves this as a string.
+
         set_var(
             "SPOX_REWARD_CLAIMS__PRIVATE_KEY",
-            "a000000000000000000000000000000000000000000000000000000000000001",
+            "0000000000000000000000000000000000000000000000000000000000000001",
         );
 
         let settings = Settings::new_from_default_config().unwrap();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,6 +8,7 @@ use bitcoincore_rpc_json::Timestamp;
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use config::{Config, Environment, File};
+use secp256k1::SecretKey;
 use serde::Deserialize;
 use url::Url;
 
@@ -77,6 +78,9 @@ pub struct StacksConfig {
     /// The address of the deployer of the sBTC smart contracts.
     #[serde(deserialize_with = "stacks_address_deserializer")]
     pub sbtc_deployer: StacksAddress,
+    /// Hex-encoded 32-byte secp256k1 private key used to sign Stacks
+    /// transactions.
+    pub private_key: SecretKey,
 }
 
 /// Bitcoin core wallet config.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,7 +68,6 @@ pub struct Settings {
     ///
     /// Presence of this stanza enables the reward-claim process. Requires
     /// [`Settings::stacks`] as well.
-    #[serde(default)]
     pub reward_claims: Option<RewardClaimsConfig>,
     /// Stacks config, used for CLI commands, registry reads, and reward claims.
     pub stacks: Option<StacksConfig>,
@@ -95,10 +94,8 @@ pub struct RewardClaimsConfig {
     /// Fully-qualified reward-claims smart contract identifier.
     #[serde(deserialize_with = "contract_deserializer")]
     pub claims_contract: QualifiedContractIdentifier,
-    /// Hex-encoded 32-byte secp256k1 private key used to sign Stacks
-    /// transactions.
-    ///
-    /// Environment: `SPOX_REWARD_CLAIMS__PRIVATE_KEY`
+    /// The private key used to sign contract call transactions to the
+    /// rewards-claim registry.
     pub private_key: SecretKey,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,8 +14,9 @@ use url::Url;
 
 use crate::config::error::SpoxConfigError;
 use crate::config::serialization::{
-    contract_deserializer_option, duration_seconds_deserializer, principal_deserializer,
-    script_deserializer, stacks_address_deserializer, url_deserializer, xonly_deserializer,
+    contract_deserializer, contract_deserializer_option, duration_seconds_deserializer,
+    principal_deserializer, script_deserializer, stacks_address_deserializer, url_deserializer,
+    xonly_deserializer,
 };
 
 pub mod error;
@@ -63,12 +64,13 @@ pub struct Settings {
     /// Registry smart contract address
     #[serde(default, deserialize_with = "contract_deserializer_option")]
     pub registry_contract: Option<QualifiedContractIdentifier>,
-    /// Whether reward-claim / settlement processing is enabled.
+    /// Reward-claim / settlement config.
     ///
-    /// When enabled, `[stacks]` must be present.
+    /// Presence of this stanza enables the reward-claim process. Requires
+    /// [`Settings::stacks`] as well.
     #[serde(default)]
-    pub reward_claims_enabled: bool,
-    /// Stacks config, used only for some CLI commands and for the registry contract
+    pub reward_claims: Option<RewardClaimsConfig>,
+    /// Stacks config, used for CLI commands, registry reads, and reward claims.
     pub stacks: Option<StacksConfig>,
     /// Bitcoin core wallet config
     pub node_wallet: Option<BitcoinCoreWalletConfig>,
@@ -83,11 +85,20 @@ pub struct StacksConfig {
     /// The address of the deployer of the sBTC smart contracts.
     #[serde(deserialize_with = "stacks_address_deserializer")]
     pub sbtc_deployer: StacksAddress,
+}
+
+/// Config for signing and submitting reward-claim transactions.
+///
+/// When this stanza is present, `[stacks]` must also be configured.
+#[derive(Deserialize, Clone, Debug)]
+pub struct RewardClaimsConfig {
+    /// Fully-qualified reward-claims smart contract identifier.
+    #[serde(deserialize_with = "contract_deserializer")]
+    pub claims_contract: QualifiedContractIdentifier,
     /// Hex-encoded 32-byte secp256k1 private key used to sign Stacks
     /// transactions.
     ///
-    /// Required when [`Settings::reward_claims_enabled`] is true.
-    /// Environment: `SPOX_STACKS__PRIVATE_KEY`
+    /// Environment: `SPOX_REWARD_CLAIMS__PRIVATE_KEY`
     pub private_key: SecretKey,
 }
 
@@ -157,10 +168,8 @@ impl Settings {
             return Err(SpoxConfigError::MissingStacksConfig);
         }
 
-        if self.reward_claims_enabled {
-            if self.stacks.is_none() {
-                return Err(SpoxConfigError::MissingStacksConfig);
-            };
+        if self.reward_claims.is_some() && self.stacks.is_none() {
+            return Err(SpoxConfigError::MissingStacksConfig);
         }
 
         if let Some(ref wallet) = self.node_wallet
@@ -228,7 +237,7 @@ mod tests {
         assert_eq!(settings.polling_interval, Duration::from_secs(30));
         assert_eq!(settings.bitcoin_rpc_timeout, Duration::from_mins(5));
         assert!(settings.registry_contract.is_none());
-        assert!(!settings.reward_claims_enabled);
+        assert!(settings.reward_claims.is_none());
         settings.stacks.as_ref().unwrap();
     }
 
@@ -340,18 +349,48 @@ mod tests {
     }
 
     #[test]
-    fn reward_claims_enabled_with_private_key_succeeds() {
+    fn reward_claims_requires_stacks_config() {
         clear_env();
 
-        set_var("SPOX_REWARD_CLAIMS_ENABLED", "true");
+        // Provide a complete [reward_claims] via env but clear stacks by using a
+        // minimal config path is hard; instead set reward_claims fields and
+        // rely on default.toml still having [stacks]. Use validate directly.
+        let mut settings = Settings::new_from_default_config().unwrap();
+        settings.stacks = None;
+        settings.reward_claims = Some(RewardClaimsConfig {
+            claims_contract: QualifiedContractIdentifier::parse(
+                "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claims",
+            )
+            .unwrap(),
+            private_key: SecretKey::from_slice(&[0xa0; 32]).unwrap(),
+        });
+
+        assert!(matches!(
+            settings.validate(),
+            Err(SpoxConfigError::MissingStacksConfig)
+        ));
+    }
+
+    #[test]
+    fn reward_claims_stanza_loads() {
+        clear_env();
+
+        set_var(
+            "SPOX_REWARD_CLAIMS__CLAIMS_CONTRACT",
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claims",
+        );
         // Include a hex letter so Environment::try_parsing leaves this as a string.
         set_var(
-            "SPOX_STACKS__PRIVATE_KEY",
+            "SPOX_REWARD_CLAIMS__PRIVATE_KEY",
             "a000000000000000000000000000000000000000000000000000000000000001",
         );
 
         let settings = Settings::new_from_default_config().unwrap();
-        assert!(settings.reward_claims_enabled);
-        settings.stacks.unwrap();
+        let claims = settings.reward_claims.unwrap();
+        assert_eq!(
+            claims.claims_contract.to_string(),
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.reward-claims"
+        );
+        assert!(settings.stacks.is_some());
     }
 }

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -72,6 +72,15 @@ where
         .map_err(serde::de::Error::custom)
 }
 
+/// Parse the string into a Stacks QualifiedContractIdentifier.
+pub fn contract_deserializer<'de, D>(des: D) -> Result<QualifiedContractIdentifier, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let literal = <String>::deserialize(des)?;
+    QualifiedContractIdentifier::parse(&literal).map_err(serde::de::Error::custom)
+}
+
 /// Parse the string into a XOnlyPublicKey
 pub fn xonly_deserializer<'de, D>(des: D) -> Result<XOnlyPublicKey, D::Error>
 where

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,8 +27,11 @@ pub struct Context {
 impl Context {
     /// Build a context from settings.
     ///
-    /// If Stacks config is present, this queries `GET /v2/info` so the wallet
-    /// can be constructed with the node's chain id.
+    /// When [`Settings::reward_claims_enabled`] is true, `[stacks]` and
+    /// `private_key` are required, and this queries `GET /v2/info` so the
+    /// signing wallet can be constructed with the node's chain id.
+    /// Nonce starts at `0`; submit paths must refresh it via `get_account` +
+    /// [`StacksWallet::set_nonce`] before signing.
     pub async fn try_new(value: &Settings) -> Result<Self, Error> {
         let bitcoin_client = BitcoinCoreClient::from_config(
             &value.bitcoin_rpc_endpoint,
@@ -52,16 +55,20 @@ impl Context {
             })
             .transpose()?;
 
-        // Nonce is left at 0 on purpose. Callers that submit transactions must
-        // set_nonce from get_account first.
-        let wallet = match value.stacks.as_ref() {
-            Some(stacks) => {
-                let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
-                let info = client.get_node_info().await?;
-                let wallet = StacksWallet::new(stacks.private_key, info.chain_id, 0);
-                Some(Arc::new(wallet))
+        let wallet = if value.reward_claims_enabled {
+            // Nonce is left at 0 on purpose. Callers that submit transactions must
+            // set_nonce from get_account first.
+            match value.stacks.as_ref() {
+                Some(stacks) => {
+                    let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
+                    let info = client.get_node_info().await?;
+                    let wallet = StacksWallet::new(stacks.private_key, info.chain_id, 0);
+                    Some(Arc::new(wallet))
+                }
+                None => return Err(Error::MissingStacksConfig),
             }
-            None => None,
+        } else {
+            None
         };
 
         Ok(Self {

--- a/src/context.rs
+++ b/src/context.rs
@@ -20,19 +20,12 @@ pub struct Context {
     storage: SharedStore,
     settings: Arc<Settings>,
     registry: Option<Arc<DepositAddressRegistry>>,
-    #[allow(dead_code)]
-    wallet: Option<Arc<StacksWallet>>,
 }
 
-impl Context {
-    /// Build a context from settings.
-    ///
-    /// When [`Settings::reward_claims_enabled`] is true, `[stacks]` and
-    /// `private_key` are required, and this queries `GET /v2/info` so the
-    /// signing wallet can be constructed with the node's chain id.
-    /// Nonce starts at `0`; submit paths must refresh it via `get_account` +
-    /// [`StacksWallet::set_nonce`] before signing.
-    pub async fn try_new(value: &Settings) -> Result<Self, Error> {
+impl TryFrom<&Settings> for Context {
+    type Error = Error;
+
+    fn try_from(value: &Settings) -> Result<Self, Self::Error> {
         let bitcoin_client = BitcoinCoreClient::from_config(
             &value.bitcoin_rpc_endpoint,
             value.node_wallet.as_ref().map(|w| w.name.as_str()),
@@ -55,30 +48,36 @@ impl Context {
             })
             .transpose()?;
 
-        let wallet = if value.reward_claims_enabled {
-            // Nonce is left at 0 on purpose. Callers that submit transactions must
-            // set_nonce from get_account first.
-            match value.stacks.as_ref() {
-                Some(stacks) => {
-                    let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
-                    let info = client.get_node_info().await?;
-                    let wallet = StacksWallet::new(stacks.private_key, info.chain_id, 0);
-                    Some(Arc::new(wallet))
-                }
-                None => return Err(Error::MissingStacksConfig),
-            }
-        } else {
-            None
-        };
-
         Ok(Self {
             bitcoin_client,
             emily_config: Arc::new(emily_config),
             storage: Store::new_shared(),
             settings: Arc::new(value.clone()),
             registry,
-            wallet,
         })
+    }
+}
+
+impl Context {
+    /// Construct a Stacks wallet given the information in the config.
+    ///
+    /// # Note
+    ///
+    /// This function reaches out to the stacks node to get the current
+    /// chain ID.
+    pub async fn wallet(&self) -> Result<StacksWallet, Error> {
+        let config = &self.settings;
+        let Some(claims) = config.reward_claims.as_ref() else {
+            return Err(Error::MissingRewardClaimsConfig);
+        };
+        let Some(stacks) = config.stacks.as_ref() else {
+            return Err(Error::MissingStacksConfig);
+        };
+
+        // Let's go and get the current chain id.
+        let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
+        let info = client.get_node_info().await?;
+        Ok(StacksWallet::new(claims.private_key, info.chain_id, 0))
     }
 
     /// Get a reference to the Bitcoin client

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ use crate::config::Settings;
 use crate::error::Error;
 use crate::stacks::node::StacksClient;
 use crate::stacks::registry::DepositAddressRegistry;
+use crate::stacks::wallet::StacksWallet;
 use crate::storage::memory::{SharedStore, Store};
 
 /// Application context
@@ -19,12 +20,16 @@ pub struct Context {
     storage: SharedStore,
     settings: Arc<Settings>,
     registry: Option<Arc<DepositAddressRegistry>>,
+    #[allow(dead_code)]
+    wallet: Option<Arc<StacksWallet>>,
 }
 
-impl TryFrom<&Settings> for Context {
-    type Error = Error;
-
-    fn try_from(value: &Settings) -> Result<Self, Self::Error> {
+impl Context {
+    /// Build a context from settings.
+    ///
+    /// If Stacks config is present, this queries `GET /v2/info` so the wallet
+    /// can be constructed with the node's chain id.
+    pub async fn try_new(value: &Settings) -> Result<Self, Error> {
         let bitcoin_client = BitcoinCoreClient::from_config(
             &value.bitcoin_rpc_endpoint,
             value.node_wallet.as_ref().map(|w| w.name.as_str()),
@@ -47,17 +52,28 @@ impl TryFrom<&Settings> for Context {
             })
             .transpose()?;
 
+        // Nonce is left at 0 on purpose. Callers that submit transactions must
+        // set_nonce from get_account first.
+        let wallet = match value.stacks.as_ref() {
+            Some(stacks) => {
+                let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
+                let info = client.get_node_info().await?;
+                let wallet = StacksWallet::new(stacks.private_key, info.chain_id, 0);
+                Some(Arc::new(wallet))
+            }
+            None => None,
+        };
+
         Ok(Self {
             bitcoin_client,
             emily_config: Arc::new(emily_config),
             storage: Store::new_shared(),
             settings: Arc::new(value.clone()),
             registry,
+            wallet,
         })
     }
-}
 
-impl Context {
     /// Get a reference to the Bitcoin client
     pub fn bitcoin_client(&self) -> &BitcoinCoreClient {
         &self.bitcoin_client

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -35,6 +35,12 @@ where
         };
 
         if let Err(error) = sender.try_send(chain_tip) {
+            // The receiver could be dropped, in which case we know that we
+            // are done and can exit.
+            if sender.is_closed() {
+                tracing::info!("bitcoin chain tip processor closed, stopping dispatch");
+                break;
+            }
             tracing::warn!(%error, "error sending new bitcoin chain tip to processor");
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -122,4 +122,8 @@ pub enum Error {
     /// Registry returned ids that do not match the requested ids
     #[error("registry returned ids that do not match the requested ids")]
     MismatchingRawAddressIds,
+
+    /// Failed to parse a hex-encoded integer from a Stacks node response.
+    #[error("could not parse hex integer: {0}")]
+    ParseHexInt(#[source] std::num::ParseIntError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,10 @@ pub enum Error {
     #[error("missing stacks configuration")]
     MissingStacksConfig,
 
+    /// Missing reward-claims configuration
+    #[error("missing reward-claims configuration")]
+    MissingRewardClaimsConfig,
+
     /// No registry contract configured
     #[error("no registry contract configured")]
     NoRegistryConfigured,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ pub mod testing;
 ///
 /// Each process should have their own channel to avoid blocking the main
 /// broadcast channel.
-pub const MAILBOX_CAPACITY: usize = 1024;
+pub const MAILBOX_CAPACITY: usize = 144;

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(TryInto::try_into)
         .collect::<Result<Vec<_>, Error>>()?;
 
-    let context = Context::try_from(&config)?;
+    let context = Context::try_new(&config).await?;
 
     match args.command {
         Some(CliCommand::GetSignersXonlyKey) => return get_signers_xonly_key(&config).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,13 +145,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             return get_deposit_address(&monitored, &args).await;
         }
         Some(CliCommand::GetRegistryAddress(args)) => {
-            let context = Context::try_new(&config).await?;
+            let context = Context::try_from(&config)?;
             return get_registry_address(&context, &args).await;
         }
         None => (),
     }
 
-    let context = Context::try_new(&config).await?;
+    let context = Context::try_from(&config)?;
     let store = context.storage();
     for monitored_deposit in monitored {
         store.add(monitored_deposit)?;
@@ -161,17 +161,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bitcoin_rpc = context.bitcoin_client().clone();
     let chain_tip_poller = BitcoinChainTipPoller::start(bitcoin_rpc, config.polling_interval).await;
-    let deposit_rx = chain_tip_poller.new_receiver();
+    let rx1 = chain_tip_poller.new_receiver();
+    let rx2 = chain_tip_poller.new_receiver();
 
-    if config.reward_claims_enabled {
-        let claims_rx = chain_tip_poller.new_receiver();
-        tokio::join!(
-            run_on_chain_tips(process_monitored_deposits, deposit_rx, context.clone()),
-            run_on_chain_tips(process_reward_claims, claims_rx, context),
-        );
-    } else {
-        run_on_chain_tips(process_monitored_deposits, deposit_rx, context).await;
-    }
+    tokio::join!(
+        run_on_chain_tips(process_monitored_deposits, rx1, context.clone()),
+        run_on_chain_tips(process_reward_claims, rx2, context),
+    );
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,19 +139,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(TryInto::try_into)
         .collect::<Result<Vec<_>, Error>>()?;
 
-    let context = Context::try_new(&config).await?;
-
     match args.command {
         Some(CliCommand::GetSignersXonlyKey) => return get_signers_xonly_key(&config).await,
         Some(CliCommand::GetDepositAddress(args)) => {
             return get_deposit_address(&monitored, &args).await;
         }
         Some(CliCommand::GetRegistryAddress(args)) => {
+            let context = Context::try_new(&config).await?;
             return get_registry_address(&context, &args).await;
         }
         None => (),
     }
 
+    let context = Context::try_new(&config).await?;
     let store = context.storage();
     for monitored_deposit in monitored {
         store.add(monitored_deposit)?;
@@ -161,13 +161,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let bitcoin_rpc = context.bitcoin_client().clone();
     let chain_tip_poller = BitcoinChainTipPoller::start(bitcoin_rpc, config.polling_interval).await;
-    let rx1 = chain_tip_poller.new_receiver();
-    let rx2 = chain_tip_poller.new_receiver();
+    let deposit_rx = chain_tip_poller.new_receiver();
 
-    tokio::join!(
-        run_on_chain_tips(process_monitored_deposits, rx1, context.clone()),
-        run_on_chain_tips(process_reward_claims, rx2, context),
-    );
+    if config.reward_claims_enabled {
+        let claims_rx = chain_tip_poller.new_receiver();
+        tokio::join!(
+            run_on_chain_tips(process_monitored_deposits, deposit_rx, context.clone()),
+            run_on_chain_tips(process_reward_claims, claims_rx, context),
+        );
+    } else {
+        run_on_chain_tips(process_monitored_deposits, deposit_rx, context).await;
+    }
 
     Ok(())
 }

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -17,6 +17,11 @@ use crate::error::Error;
 /// The loop for processing reward claims that runs whenever a new Bitcoin
 /// block is detected.
 pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Context) {
+    if context.settings().reward_claims.is_none() {
+        tracing::info!("reward claims are not configured, skipping");
+        return;
+    }
+
     while let Some(chain_tip) = rx.recv().await {
         if let Err(error) = process_pending_claims(&context, &chain_tip).await {
             tracing::warn!(%error, "error processing pending reward claims");

--- a/src/stacks/mod.rs
+++ b/src/stacks/mod.rs
@@ -4,3 +4,4 @@ pub mod clarity;
 pub mod node;
 pub mod registry;
 pub mod reward_claim_registry;
+pub mod wallet;

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -4,8 +4,9 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use bitcoin::{PublicKey, XOnlyPublicKey};
+use clarity::types::chainstate::BlockHeaderHash;
+use clarity::types::chainstate::ConsensusHash;
 use clarity::types::chainstate::StacksAddress;
-use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::types::{BuffData, SequenceData};
 use clarity::vm::{ClarityName, ContractName, Value};
 use serde::{Deserialize, Deserializer};
@@ -72,8 +73,10 @@ pub struct NodeInfo {
     /// Stacks chain id reported by the node.
     #[serde(rename = "network_id")]
     pub chain_id: u32,
-    /// Index block hash of the tip of the canonical Stacks chain.
-    pub stacks_tip: StacksBlockId,
+    /// Block header hash of the tip of the canonical Stacks chain.
+    pub stacks_tip: BlockHeaderHash,
+    /// Consensus hash of the tip of the canonical Stacks chain.
+    pub stacks_tip_consensus_hash: ConsensusHash,
 }
 
 /// Helper function for converting a hexadecimal string into an integer.
@@ -509,10 +512,14 @@ mod tests {
         assert_eq!(info.chain_id, blockstack_lib::core::CHAIN_ID_TESTNET);
         assert_eq!(
             info.stacks_tip,
-            StacksBlockId::from_hex(
+            BlockHeaderHash::from_hex(
                 "b5f9aa4423ffa7abb585fc00e2783c40225597ec112ee618db86ae23dbbbe88c"
             )
             .unwrap()
+        );
+        assert_eq!(
+            info.stacks_tip_consensus_hash,
+            ConsensusHash::from_hex("dfe87cfd31c1a67fa8b989c83b79aa476e616758").unwrap()
         );
         mock.assert();
     }

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -45,9 +45,13 @@ pub struct CallReadResponse {
 /// JSON body returned by GET /v2/accounts/<principal>.
 #[derive(Debug, Deserialize)]
 struct AccountEntryResponse {
+    /// Hex-encoded total balance in micro-STX, including locked funds.
     balance: String,
+    /// Hex-encoded amount locked (stacked) in micro-STX.
     locked: String,
+    /// Stacks block height at which the locked micro-STX unlock.
     unlock_height: u64,
+    /// Next nonce for the account.
     nonce: u64,
 }
 

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use bitcoin::{PublicKey, XOnlyPublicKey};
 use clarity::types::chainstate::StacksAddress;
+use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::types::{BuffData, SequenceData};
 use clarity::vm::{ClarityName, ContractName, Value};
 use serde::{Deserialize, Deserializer};
@@ -38,6 +39,60 @@ pub struct CallReadResponse {
     /// The result of the function call.
     #[serde(deserialize_with = "clarity_value_deserializer")]
     pub result: Value,
+}
+
+/// JSON body returned by GET /v2/accounts/<principal>.
+#[derive(Debug, Deserialize)]
+struct AccountEntryResponse {
+    balance: String,
+    locked: String,
+    unlock_height: u64,
+    nonce: u64,
+}
+
+/// Account info for a Stacks address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountInfo {
+    /// The total balance of the account in micro-STX, including locked funds.
+    pub balance: u128,
+    /// The amount locked (stacked) in micro-STX.
+    pub locked: u128,
+    /// The height of the stacks block where the locked micro-STX unlock.
+    pub unlock_height: u64,
+    /// The next nonce for the account.
+    pub nonce: u64,
+}
+
+/// Subset of the response from `GET /v2/info`.
+///
+/// Despite the field name, `network_id` is the Stacks chain id used in
+/// transactions.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct NodeInfo {
+    /// Stacks chain id reported by the node.
+    #[serde(rename = "network_id")]
+    pub chain_id: u32,
+    /// Index block hash of the tip of the canonical Stacks chain.
+    pub stacks_tip: StacksBlockId,
+}
+
+/// Helper function for converting a hexadecimal string into an integer.
+fn parse_hex_u128(hex: &str) -> Result<u128, Error> {
+    let hex_str = hex.trim_start_matches("0x");
+    u128::from_str_radix(hex_str, 16).map_err(Error::ParseHexInt)
+}
+
+impl TryFrom<AccountEntryResponse> for AccountInfo {
+    type Error = Error;
+
+    fn try_from(value: AccountEntryResponse) -> Result<Self, Self::Error> {
+        Ok(AccountInfo {
+            balance: parse_hex_u128(&value.balance)?,
+            locked: parse_hex_u128(&value.locked)?,
+            unlock_height: value.unlock_height,
+            nonce: value.nonce,
+        })
+    }
 }
 
 /// A client for interacting with Stacks nodes and the Stacks API
@@ -158,6 +213,66 @@ impl StacksClient {
             .await
             .map_err(Error::UnexpectedStacksResponse)
             .map(|x| x.result)
+    }
+
+    /// Get the latest account info for the given address.
+    ///
+    /// This is done by making a `GET /v2/accounts/<principal>` request. In
+    /// the request we specify that the nonce and balance proofs should not
+    /// be included in the response.
+    #[tracing::instrument(skip_all)]
+    pub async fn get_account(&self, address: &StacksAddress) -> Result<AccountInfo, Error> {
+        let path = format!("/v2/accounts/{address}?proof=0");
+        let url = self
+            .endpoint
+            .join(&path)
+            .map_err(|err| Error::PathJoin(err, self.endpoint.clone(), Cow::Owned(path)))?;
+
+        tracing::debug!(%address, "fetching the latest account information");
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(Error::StacksNodeRequest)?;
+
+        response
+            .error_for_status()
+            .map_err(Error::StacksNodeResponse)?
+            .json::<AccountEntryResponse>()
+            .await
+            .map_err(Error::UnexpectedStacksResponse)
+            .and_then(AccountInfo::try_from)
+    }
+
+    /// Get node info from `GET /v2/info`.
+    ///
+    /// Used to discover the chain id (`network_id`) for wallet and transaction
+    /// construction whenever a stacks RPC endpoint is configured.
+    #[tracing::instrument(skip_all)]
+    pub async fn get_node_info(&self) -> Result<NodeInfo, Error> {
+        let path = "/v2/info";
+        let url = self
+            .endpoint
+            .join(path)
+            .map_err(|err| Error::PathJoin(err, self.endpoint.clone(), Cow::Borrowed(path)))?;
+
+        tracing::debug!("fetching stacks node info");
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(Error::StacksNodeRequest)?;
+
+        response
+            .error_for_status()
+            .map_err(Error::StacksNodeResponse)?
+            .json::<NodeInfo>()
+            .await
+            .map_err(Error::UnexpectedStacksResponse)
     }
 
     /// Retrieve the current signers' aggregate key from the `sbtc-registry`
@@ -297,6 +412,108 @@ mod tests {
 
         // Assert that the response is what we expect
         assert_eq!(resp, expected);
+        mock.assert();
+    }
+
+    #[test_case("0x1A3B5C7D9E", 112665066910; "uppercase-112665066910")]
+    #[test_case("0x1a3b5c7d9e", 112665066910; "lowercase-112665066910")]
+    #[test_case("1a3b5c7d9e", 112665066910; "no-prefix-lowercase-112665066910")]
+    #[test_case("0xF0", 240; "uppercase-240")]
+    #[test_case("f0", 240; "no-prefix-lowercase-240")]
+    fn parsing_integers(hex: &str, expected: u128) {
+        let actual = parse_hex_u128(hex).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test_case(""; "empty-string")]
+    #[test_case("0x"; "almost-empty-string")]
+    #[test_case("ZZZ"; "invalid hex")]
+    fn parsing_integers_bad_input(hex: &str) {
+        assert!(parse_hex_u128(hex).is_err());
+    }
+
+    #[tokio::test]
+    async fn get_account_happy_path() {
+        let address =
+            StacksAddress::from_string("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap();
+
+        let raw_json_response = r#"{
+            "balance": "0x64",
+            "locked": "0x0a",
+            "unlock_height": 100,
+            "nonce": 7
+        }"#;
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let path = format!("/v2/accounts/{address}?proof=0");
+        let mock = stacks_node_server
+            .mock("GET", path.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url).unwrap();
+
+        let account = client.get_account(&address).await.unwrap();
+        assert_eq!(
+            account,
+            AccountInfo {
+                balance: 100,
+                locked: 10,
+                unlock_height: 100,
+                nonce: 7,
+            }
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn get_node_info_returns_network_id() {
+        // Minimal /v2/info body; serde ignores unknown fields.
+        let raw_json_response = r#"{
+            "peer_version": 4207599117,
+            "pox_consensus": "dfe87cfd31c1a67fa8b989c83b79aa476e616758",
+            "burn_block_height": 859080,
+            "stable_pox_consensus": "c37cfa14d83c0e8dd87b8060adaf326dd60826d1",
+            "stable_burn_block_height": 859073,
+            "server_version": "stacks-node 0.0.1",
+            "network_id": 2147483648,
+            "parent_network_id": 3652501241,
+            "stacks_tip_height": 123,
+            "stacks_tip": "b5f9aa4423ffa7abb585fc00e2783c40225597ec112ee618db86ae23dbbbe88c",
+            "stacks_tip_consensus_hash": "dfe87cfd31c1a67fa8b989c83b79aa476e616758",
+            "genesis_chainstate_hash": "74237aa196aa178594804234417b84c7b4473cff69045cb7c5abf34e580ea427",
+            "unanchored_tip": null,
+            "unanchored_seq": null,
+            "tenure_height": 100,
+            "exit_at_block_height": null,
+            "is_fully_synced": true
+        }"#;
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock("GET", "/v2/info")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url).unwrap();
+
+        let info = client.get_node_info().await.unwrap();
+        assert_eq!(info.chain_id, blockstack_lib::core::CHAIN_ID_TESTNET);
+        assert_eq!(
+            info.stacks_tip,
+            StacksBlockId::from_hex(
+                "b5f9aa4423ffa7abb585fc00e2783c40225597ec112ee618db86ae23dbbbe88c"
+            )
+            .unwrap()
+        );
         mock.assert();
     }
 }

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -35,9 +35,13 @@ use secp256k1::ecdsa::RecoverableSignature;
 /// equals [`CHAIN_ID_MAINNET`].
 #[derive(Debug)]
 pub struct StacksWallet {
+    /// Secp256k1 private key used to sign transactions.
     secret_key: SecretKey,
+    /// Stacks address derived from [`Self::secret_key`] for this chain.
     address: StacksAddress,
+    /// Stacks chain id written into signed transactions.
     chain_id: u32,
+    /// Local next-nonce counter.
     nonce: AtomicU64,
 }
 

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -1,0 +1,258 @@
+//! Single-sig Stacks wallet for building and signing transactions.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use blockstack_lib::chainstate::stacks::SinglesigHashMode;
+use blockstack_lib::chainstate::stacks::SinglesigSpendingCondition;
+use blockstack_lib::chainstate::stacks::StacksTransaction;
+use blockstack_lib::chainstate::stacks::TransactionAnchorMode;
+use blockstack_lib::chainstate::stacks::TransactionAuth;
+use blockstack_lib::chainstate::stacks::TransactionAuthFlags;
+use blockstack_lib::chainstate::stacks::TransactionPayload;
+use blockstack_lib::chainstate::stacks::TransactionPostConditionMode;
+use blockstack_lib::chainstate::stacks::TransactionPublicKeyEncoding;
+use blockstack_lib::chainstate::stacks::TransactionSpendingCondition;
+use blockstack_lib::chainstate::stacks::TransactionVersion;
+use blockstack_lib::core::CHAIN_ID_MAINNET;
+use blockstack_lib::util::secp256k1::MessageSignature;
+use blockstack_lib::util::secp256k1::Secp256k1PublicKey;
+use clarity::types::chainstate::StacksAddress;
+use secp256k1::PublicKey;
+use secp256k1::SECP256K1;
+use secp256k1::SecretKey;
+use secp256k1::ecdsa::RecoverableSignature;
+
+/// A single-sig Stacks wallet that tracks a local nonce counter.
+///
+/// The nonce starts at whatever value is passed to [`StacksWallet::new`] (typically `0`)
+/// and is incremented when building transaction auth via [`StacksWallet::as_unsigned_tx_auth`].
+/// Callers must refresh the nonce from the node with [`StacksWallet::set_nonce`] (after
+/// `get_account`) before submitting transactions.
+///
+/// `chain_id` is the exact value from the stacks node's `/v2/info` `network_id` field and is
+/// written into signed transactions. Address version bytes only depend on whether that value
+/// equals [`CHAIN_ID_MAINNET`].
+#[derive(Debug)]
+pub struct StacksWallet {
+    secret_key: SecretKey,
+    address: StacksAddress,
+    chain_id: u32,
+    nonce: AtomicU64,
+}
+
+impl StacksWallet {
+    /// Create a new single-sig wallet for the given chain id.
+    ///
+    /// The Stacks address is the P2PKH address derived from the compressed public key.
+    /// `chain_id` should be the `network_id` returned by `GET /v2/info`.
+    pub fn new(secret_key: SecretKey, chain_id: u32, nonce: u64) -> Self {
+        let public_key = PublicKey::from_secret_key(SECP256K1, &secret_key);
+        let stacks_public_key = Secp256k1PublicKey::from_slice(&public_key.serialize())
+            .expect("compressed secp256k1 public key should convert to stacks public key");
+
+        let is_mainnet = chain_id == CHAIN_ID_MAINNET;
+        let address = StacksAddress::p2pkh(is_mainnet, &stacks_public_key);
+
+        Self {
+            secret_key,
+            address,
+            chain_id,
+            nonce: AtomicU64::new(nonce),
+        }
+    }
+
+    /// The Stacks P2PKH address for this wallet.
+    pub fn address(&self) -> &StacksAddress {
+        &self.address
+    }
+
+    /// Whether this wallet is configured for Stacks mainnet.
+    pub fn is_mainnet(&self) -> bool {
+        self.chain_id == CHAIN_ID_MAINNET
+    }
+
+    /// Set the next nonce to the provided value (typically from `get_account`).
+    pub fn set_nonce(&self, value: u64) {
+        self.nonce.store(value, Ordering::Relaxed);
+    }
+
+    /// Build an unsigned single-sig spending condition and advance the local nonce.
+    ///
+    /// The returned spending condition has a fee and nonce set, but an empty signature.
+    pub fn as_unsigned_tx_auth(&self, tx_fee: u64) -> SinglesigSpendingCondition {
+        SinglesigSpendingCondition {
+            signer: self.address.bytes().clone(),
+            nonce: self.nonce.fetch_add(1, Ordering::Relaxed),
+            tx_fee,
+            hash_mode: SinglesigHashMode::P2PKH,
+            key_encoding: TransactionPublicKeyEncoding::Compressed,
+            signature: MessageSignature::empty(),
+        }
+    }
+
+    /// Build and sign a Stacks transaction for the given payload.
+    ///
+    /// This advances the local nonce via [`StacksWallet::as_unsigned_tx_auth`].
+    pub fn sign_tx(&self, payload: TransactionPayload, tx_fee: u64) -> StacksTransaction {
+        use TransactionSpendingCondition::Singlesig;
+
+        let version = if self.is_mainnet() {
+            TransactionVersion::Mainnet
+        } else {
+            TransactionVersion::Testnet
+        };
+
+        let auth = self.as_unsigned_tx_auth(tx_fee);
+        let mut tx = StacksTransaction {
+            version,
+            chain_id: self.chain_id,
+            auth: TransactionAuth::Standard(Singlesig(auth)),
+            anchor_mode: TransactionAnchorMode::Any,
+            post_condition_mode: TransactionPostConditionMode::Allow,
+            post_conditions: Vec::new(),
+            payload,
+        };
+
+        let msg = secp256k1::Message::from_digest(tx_digest(&tx));
+        let signature = SECP256K1.sign_ecdsa_recoverable(&msg, &self.secret_key);
+
+        let TransactionAuth::Standard(Singlesig(cond)) = &mut tx.auth else {
+            unreachable!("what!? we just created this a few lines above");
+        };
+        cond.set_signature(signature.as_stacks_sig());
+
+        tx
+    }
+}
+
+/// Construct the digest that each signer needs to sign from a given
+/// transaction.
+///
+/// # Note
+///
+/// This function follows the same procedure as the
+/// [`TransactionSpendingCondition::next_signature`] function in
+/// stacks-core, except that it stops after the digest is created.
+fn tx_digest(tx: &StacksTransaction) -> [u8; 32] {
+    let mut cleared_tx = tx.clone();
+    cleared_tx.auth = cleared_tx.auth.into_initial_sighash_auth();
+
+    let sighash = cleared_tx.txid();
+    let flags = TransactionAuthFlags::AuthStandard;
+    let tx_fee = tx.get_tx_fee();
+    let nonce = tx.get_origin_nonce();
+
+    TransactionSpendingCondition::make_sighash_presign(&sighash, &flags, tx_fee, nonce).into_bytes()
+}
+
+/// This trait is to add additional functionality to the
+/// [`RecoverableSignature`] type
+pub trait RecoverableEcdsaSignature: Sized {
+    /// Convert a recoverable signature into compact bytes.
+    fn to_byte_array(&self) -> [u8; 65];
+    /// Convert this type to the equivalent stacks signature
+    fn as_stacks_sig(&self) -> MessageSignature {
+        MessageSignature(self.to_byte_array())
+    }
+}
+
+impl RecoverableEcdsaSignature for RecoverableSignature {
+    /// Convert a recoverable signature into a byte array.
+    ///
+    /// The [`RecoverableSignature`] type is a wrapper of a wrapper for
+    /// [u8; 65]. Unfortunately, the outermost wrapper type does not
+    /// provide a way to get at the underlying bytes except through the
+    /// [`RecoverableSignature::serialize_compact`] function, so we use
+    /// that function to extract the bytes.
+    ///
+    /// This function is basically lifted from stacks-core at:
+    /// https://github.com/stacks-network/stacks-core/blob/35d0840c626d258f1e2d72becdcf207a0572ddcd/stacks-common/src/util/secp256k1.rs#L88-L95
+    fn to_byte_array(&self) -> [u8; 65] {
+        let (recovery_id, bytes) = self.serialize_compact();
+        let mut ret_bytes = [0u8; 65];
+        // The recovery ID will be 0, 1, 2, or 3 as described in the secp256k1 docs:
+        // https://docs.rs/secp256k1/0.30.0/secp256k1/ecdsa/enum.RecoveryId.html
+        ret_bytes[0] = recovery_id.to_i32() as u8;
+
+        ret_bytes[1..].copy_from_slice(&bytes[..]);
+        ret_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use blockstack_lib::chainstate::stacks::TokenTransferMemo;
+    use blockstack_lib::chainstate::stacks::TransactionPayload;
+    use blockstack_lib::core::CHAIN_ID_TESTNET;
+    use clarity::types::chainstate::StacksAddress;
+    use clarity::vm::types::PrincipalData;
+    use secp256k1::SecretKey;
+
+    use super::*;
+
+    fn test_secret_key() -> SecretKey {
+        SecretKey::from_slice(&[0x11; 32]).expect("valid secret key")
+    }
+
+    fn token_transfer_payload(recipient: &StacksAddress) -> TransactionPayload {
+        let principal = PrincipalData::from(recipient.clone());
+        TransactionPayload::TokenTransfer(principal, 1, TokenTransferMemo([0u8; 34]))
+    }
+
+    impl StacksWallet {
+        fn nonce(&self) -> u64 {
+            self.nonce.load(Ordering::SeqCst)
+        }
+    }
+
+    #[test]
+    fn as_unsigned_tx_auth_increments_nonce() {
+        let wallet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 7);
+
+        let auth0 = wallet.as_unsigned_tx_auth(1000);
+        assert_eq!(auth0.nonce, 7);
+        assert_eq!(wallet.nonce(), 8);
+
+        let auth1 = wallet.as_unsigned_tx_auth(1000);
+        assert_eq!(auth1.nonce, 8);
+        assert_eq!(wallet.nonce(), 9);
+    }
+
+    #[test]
+    fn sign_tx_produces_verifiable_transaction() {
+        let wallet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 0);
+        let payload = token_transfer_payload(wallet.address());
+
+        let tx = wallet.sign_tx(payload, 1000);
+        assert!(tx.verify().is_ok());
+        assert_eq!(tx.chain_id, CHAIN_ID_TESTNET);
+        assert_eq!(wallet.nonce(), 1);
+    }
+
+    #[test]
+    fn set_nonce_updates_counter() {
+        let wallet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 0);
+        wallet.set_nonce(42);
+        assert_eq!(wallet.nonce(), 42);
+
+        let auth = wallet.as_unsigned_tx_auth(1);
+        assert_eq!(auth.nonce, 42);
+        assert_eq!(wallet.nonce(), 43);
+    }
+
+    #[test]
+    fn mainnet_chain_id_selects_mainnet_address_version() {
+        let mainnet = StacksWallet::new(test_secret_key(), CHAIN_ID_MAINNET, 0);
+        let testnet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 0);
+
+        assert!(mainnet.is_mainnet());
+        assert!(!testnet.is_mainnet());
+        assert_ne!(mainnet.address().to_string(), testnet.address().to_string());
+        assert!(mainnet.address().to_string().starts_with('S'));
+        assert!(testnet.address().to_string().starts_with('S'));
+        // Mainnet singlesig addresses use the SP prefix; testnet uses ST.
+        assert!(mainnet.address().to_string().starts_with("SP"));
+        assert!(testnet.address().to_string().starts_with("ST"));
+    }
+}


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/43

## Changes

* Add a wallet module with a struct that we can use for signing contract calls.
* Add functionality for fetching an account nonce and the Stacks node info. We need the chain ID and the chain tip from that endpoint.
* Add configuration values for the wallet and claim registry.

## Testing Information

Not much, yet. This new code is almost entirely unused.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
