### PR TITLE
feat: constructing `process-reward-claims` payload

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -119,6 +119,10 @@ pub enum Error {
     #[error("response from stacks node did not conform to the expected schema: {0}")]
     UnexpectedStacksResponse(#[source] reqwest::Error),
 
+    /// Reqwest error
+    #[error("The clarity principal was not a smart contract principal: {0}")]
+    UnexpectedPrincipal(clarity::vm::Value),
+
     /// Unexpected local timestamp
     #[error("unexpected local timestamp")]
     UnexpectedLocalTimestamp,

--- a/src/error.rs
+++ b/src/error.rs
@@ -119,7 +119,9 @@ pub enum Error {
     #[error("response from stacks node did not conform to the expected schema: {0}")]
     UnexpectedStacksResponse(#[source] reqwest::Error),
 
-    /// Reqwest error
+    /// This variant is for when the clarity principal returned from our
+    /// read-only call for the signer manager is not a qualitfied contract
+    /// identifier.
     #[error("The clarity principal was not a smart contract principal: {0}")]
     UnexpectedPrincipal(clarity::vm::Value),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,9 +121,10 @@ pub enum Error {
 
     /// This variant is for when the clarity principal returned from our
     /// read-only call for the signer manager is not a qualitfied contract
-    /// identifier.
-    #[error("The clarity principal was not a smart contract principal: {0}")]
-    UnexpectedPrincipal(clarity::vm::Value),
+    /// identifier. This should never happen, seeing it means we have a bug
+    /// in the smart contract.
+    #[error("the clarity principal was not a smart contract principal")]
+    UnexpectedPrincipal(clarity::vm::types::PrincipalData),
 
     /// Unexpected local timestamp
     #[error("unexpected local timestamp")]

--- a/src/stacks/mod.rs
+++ b/src/stacks/mod.rs
@@ -4,4 +4,5 @@ pub mod clarity;
 pub mod node;
 pub mod registry;
 pub mod reward_claim_registry;
+pub mod transaction;
 pub mod wallet;

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -198,7 +198,6 @@ impl TryFrom<ClarityValue> for PendingClaim {
             // This should never happen, because registration checks that
             // the signer manager implements a trait and only smart
             // contract principals can implement traits.
-            let signer_manager = ClarityValue::from(signer_manager);
             return Err(Error::UnexpectedPrincipal(signer_manager));
         };
 

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -62,8 +62,9 @@ pub struct PendingClaimsPage {
 
 /// Arguments for one `process-reward-claims` contract call.
 ///
-/// All [`Self::stakers`] share [`Self::signer_manager`], and the list length is
-/// at most [`PROCESS_REWARD_CLAIMS_MAX_STAKERS`].
+/// All [`Self::stakers`] share [`Self::signer_manager`], and the list
+/// length is at most [`PROCESS_REWARD_CLAIMS_MAX_STAKERS`]. (TODO: enforce
+/// this at construction time)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessRewardClaimsBatch {
     /// Signer-manager trait principal passed to `process-reward-claims`.

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -63,8 +63,8 @@ pub struct PendingClaimsPage {
 /// Arguments for one `process-reward-claims` contract call.
 ///
 /// All [`Self::stakers`] share [`Self::signer_manager`], and the list
-/// length is at most [`PROCESS_REWARD_CLAIMS_MAX_STAKERS`]. (TODO: enforce
-/// this at construction time)
+/// length is at most [`MAX_STAKERS_LENGTH`]. (TODO: enforce this at
+/// construction time)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessRewardClaimsBatch {
     /// Signer-manager trait principal passed to `process-reward-claims`.

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -12,6 +12,9 @@ use crate::error::Error;
 use crate::stacks::clarity::ClarityTuple;
 use crate::stacks::node::StacksClient;
 
+/// Maximum number of stakers accepted by `process-reward-claims` in one call.
+pub const PROCESS_REWARD_CLAIMS_MAX_STAKERS: usize = 100;
+
 /// Key identifying a registration in the reward claim registry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegistrationKey {
@@ -25,7 +28,7 @@ pub struct RegistrationKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingClaim {
     /// The signer-manager principal for this registration.
-    pub signer_manager: PrincipalData,
+    pub signer_manager: QualifiedContractIdentifier,
     /// The staker principal for this registration.
     pub staker: PrincipalData,
     /// Bond index when the staker is in a bond; `None` for STX-only stakes.
@@ -39,7 +42,7 @@ impl PendingClaim {
     pub fn registration_key(&self) -> RegistrationKey {
         RegistrationKey {
             staker: self.staker.clone(),
-            signer_manager: self.signer_manager.clone(),
+            signer_manager: PrincipalData::Contract(self.signer_manager.clone()),
         }
     }
 }
@@ -55,6 +58,20 @@ pub struct PendingClaimsPage {
     /// `Some` is the last visited registration key, which may not be a
     /// pending claim itself.
     pub next: Option<RegistrationKey>,
+}
+
+/// Arguments for one `process-reward-claims` contract call.
+///
+/// All [`Self::stakers`] share [`Self::signer_manager`], and the list length is
+/// at most [`PROCESS_REWARD_CLAIMS_MAX_STAKERS`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessRewardClaimsBatch {
+    /// Signer-manager trait principal passed to `process-reward-claims`.
+    pub signer_manager: QualifiedContractIdentifier,
+    /// Staker principals to claim for in this call (1..=100).
+    pub stakers: Vec<PrincipalData>,
+    /// The address that deployed the rewards claim registry.
+    pub deployer: StacksAddress,
 }
 
 /// Client for querying the on-chain reward claim registry contract.
@@ -175,8 +192,17 @@ impl TryFrom<ClarityValue> for PendingClaim {
             })
             .transpose()?;
 
+        let signer_manager = clarity_map.remove_principal("signer-manager")?;
+        let PrincipalData::Contract(signer_manager) = signer_manager else {
+            // This should never happen, because registration checks that
+            // the signer manager implements a trait and only smart
+            // contract principals can implement traits.
+            let signer_manager = ClarityValue::from(signer_manager);
+            return Err(Error::UnexpectedPrincipal(signer_manager));
+        };
+
         Ok(PendingClaim {
-            signer_manager: clarity_map.remove_principal("signer-manager")?,
+            signer_manager,
             staker: clarity_map.remove_principal("staker")?,
             bond_index,
             reward_cycle: clarity_map.remove_uint("reward-cycle")?,
@@ -220,7 +246,7 @@ mod tests {
             let tuple_entries = vec![
                 (
                     ClarityName::from("signer-manager"),
-                    ClarityValue::Principal(value.signer_manager.clone()),
+                    ClarityValue::Principal(PrincipalData::Contract(value.signer_manager.clone())),
                 ),
                 (
                     ClarityName::from("staker"),
@@ -277,12 +303,13 @@ mod tests {
     #[tokio::test]
     async fn get_pending_claims_works_without_cursor() {
         let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
-        let signer_manager =
-            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
-                .unwrap();
+        let signer_manager = QualifiedContractIdentifier::parse(
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
+        )
+        .unwrap();
 
         let claim = PendingClaim {
-            signer_manager: signer_manager.clone(),
+            signer_manager,
             staker: staker.clone(),
             bond_index: None,
             reward_cycle: 42,
@@ -337,13 +364,14 @@ mod tests {
     #[tokio::test]
     async fn get_pending_claims_works_with_cursor() {
         let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
-        let signer_manager =
-            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
-                .unwrap();
+        let signer_manager = QualifiedContractIdentifier::parse(
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
+        )
+        .unwrap();
 
         let cursor = RegistrationKey {
             staker: staker.clone(),
-            signer_manager: signer_manager.clone(),
+            signer_manager: PrincipalData::Contract(signer_manager.clone()),
         };
 
         let claim = PendingClaim {
@@ -439,14 +467,15 @@ mod tests {
 
     #[tokio::test]
     async fn get_all_pending_claims_continues_on_empty_rows_with_next() {
-        let signer_manager =
-            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager")
-                .unwrap();
+        let signer_manager = QualifiedContractIdentifier::parse(
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
+        )
+        .unwrap();
 
         // First page: ticks burned on non-pending nodes, resume cursor only.
         let skipped = RegistrationKey {
             staker: PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap(),
-            signer_manager: signer_manager.clone(),
+            signer_manager: PrincipalData::Contract(signer_manager.clone()),
         };
         let pending = PendingClaim {
             signer_manager: signer_manager.clone(),

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -13,7 +13,7 @@ use crate::stacks::clarity::ClarityTuple;
 use crate::stacks::node::StacksClient;
 
 /// Maximum number of stakers accepted by `process-reward-claims` in one call.
-pub const PROCESS_REWARD_CLAIMS_MAX_STAKERS: usize = 100;
+pub const MAX_STAKERS_LENGTH: usize = 100;
 
 /// Key identifying a registration in the reward claim registry.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -1,0 +1,141 @@
+//!  For constructing Stacks transactions that interact with the
+//!  reward-claim registry.
+
+use std::sync::LazyLock;
+
+use blockstack_lib::chainstate::stacks::TransactionContractCall;
+use blockstack_lib::chainstate::stacks::TransactionPayload;
+use blockstack_lib::chainstate::stacks::TransactionPostCondition;
+use blockstack_lib::chainstate::stacks::TransactionPostConditionMode;
+use blockstack_lib::clarity::vm::ClarityName;
+use blockstack_lib::clarity::vm::ContractName;
+use blockstack_lib::clarity::vm::Value as ClarityValue;
+use blockstack_lib::clarity::vm::types::ListData;
+use blockstack_lib::clarity::vm::types::ListTypeData;
+use blockstack_lib::clarity::vm::types::SequenceData;
+use blockstack_lib::types::chainstate::StacksAddress;
+use clarity::vm::types::CallableData;
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::types::StandardPrincipalData;
+use clarity::vm::types::TraitIdentifier;
+use clarity::vm::types::TypeSignature;
+
+use crate::stacks::reward_claim_registry::PROCESS_REWARD_CLAIMS_MAX_STAKERS;
+use crate::stacks::reward_claim_registry::ProcessRewardClaimsBatch;
+
+const MAX_STAKERS_LENGTH: u32 = PROCESS_REWARD_CLAIMS_MAX_STAKERS as u32;
+
+/// The type signature for the list of 100 stakers.
+///
+/// ListTypeData::new_list only returns an Err when max_len is greater than MiB
+const LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
+    ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH).unwrap()
+});
+
+/// The name of the trait that signer managers must implement.
+const REWARD_CLAIM_TRAIT_NAME: &'static str = "reward-claim-signer-manager-trait";
+
+/// The name of the contract that contains the signer manager trait.
+const REWARD_CLAIM_TRAIT_CONTRACT: &'static str = "reward-claim-traits";
+
+/// This function creates a Trait identifier for the
+/// [`REWARD_CLAIM_TRAIT_NAME`] trait, once we know the issuer/deployer.
+fn make_trait_identifier(deployer: StacksAddress) -> TraitIdentifier {
+    TraitIdentifier {
+        name: ClarityName::from(REWARD_CLAIM_TRAIT_NAME),
+        contract_identifier: QualifiedContractIdentifier {
+            name: ContractName::try_from(REWARD_CLAIM_TRAIT_CONTRACT).unwrap(),
+            issuer: StandardPrincipalData::from(deployer),
+        },
+    }
+}
+
+/// A struct describing any transaction post-execution conditions that we'd
+/// like to enforce.
+///
+/// # Note
+///
+/// * It's unlikely that this will be necessary since the signers control
+///   the contract to begin with, we implicitly trust it.
+/// * We cannot enforce any conditions on the destination of any sBTC, just
+///   the source and the amount.
+/// * SIP-005 describes the post conditions, including its limitations, and
+///   can be found here
+///   https://github.com/stacksgov/sips/blob/main/sips/sip-005/sip-005-blocks-and-transactions.md#transaction-post-conditions
+#[derive(Debug)]
+pub struct StacksTxPostConditions {
+    /// Specifies whether other asset transfers not covered by the
+    /// post-conditions are permitted.
+    pub post_condition_mode: TransactionPostConditionMode,
+    /// Any post-execution conditions that we'd like to enforce.
+    pub post_conditions: Vec<TransactionPostCondition>,
+}
+
+/// A trait to ease construction of a StacksTransaction making sBTC related
+/// contract calls.
+pub trait AsContractCall {
+    /// The name of the clarity smart contract that relates to this struct.
+    const CONTRACT_NAME: &'static str;
+    /// The specific function name that relates to this struct.
+    const FUNCTION_NAME: &'static str;
+    /// The stacks address that deployed the contract.
+    fn deployer_address(&self) -> &StacksAddress;
+    /// The arguments to the clarity function.
+    fn as_contract_args(&self) -> Vec<ClarityValue>;
+    /// Convert this struct to a Stacks contract call.
+    fn as_contract_call(&self) -> TransactionContractCall {
+        TransactionContractCall {
+            address: self.deployer_address().clone(),
+            // The following From::from calls are more dangerous than they
+            // appear. Under the hood they call their TryFrom::try_from
+            // implementation and then unwrap them(!). We check that this
+            // is fine in our test.
+            function_name: ClarityName::from(Self::FUNCTION_NAME),
+            contract_name: ContractName::from(Self::CONTRACT_NAME),
+            function_args: self.as_contract_args(),
+        }
+    }
+    /// The payload of the transaction
+    fn tx_payload(&self) -> TransactionPayload {
+        TransactionPayload::ContractCall(self.as_contract_call())
+    }
+    /// Any post-execution conditions that we'd like to enforce. The
+    /// deployer corresponds to the principal in the Transaction
+    /// post-conditions, which is the address that sent the asset. The
+    /// default is that we do not enforce any conditions since we usually
+    /// deployed the contract.
+    fn post_conditions(&self) -> StacksTxPostConditions {
+        StacksTxPostConditions {
+            post_condition_mode: TransactionPostConditionMode::Allow,
+            post_conditions: Vec::new(),
+        }
+    }
+}
+
+impl AsContractCall for ProcessRewardClaimsBatch {
+    /// The name of the clarity smart contract that relates to this struct.
+    const CONTRACT_NAME: &'static str = "reward-claim-registry";
+    /// The specific function name that relates to this struct.
+    const FUNCTION_NAME: &'static str = "process-reward-claims";
+    /// The stacks address that deployed the contract.
+    fn deployer_address(&self) -> &StacksAddress {
+        &self.deployer
+    }
+    /// The arguments to the clarity function.
+    fn as_contract_args(&self) -> Vec<ClarityValue> {
+        let callable = CallableData {
+            contract_identifier: self.signer_manager.clone(),
+            trait_identifier: Some(make_trait_identifier(self.deployer.clone())),
+        };
+        let stakers = self.stakers.iter().cloned().map(ClarityValue::Principal);
+        let stakers = ListData {
+            data: stakers.collect(),
+            type_signature: LIST_PRINCIPALS_SIGNATURE.clone(),
+        };
+
+        vec![
+            ClarityValue::CallableContract(callable),
+            ClarityValue::Sequence(SequenceData::List(stakers)),
+        ]
+    }
+}

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -25,11 +25,11 @@ use crate::stacks::reward_claim_registry::ProcessRewardClaimsBatch;
 
 /// The type signature for the list of 100 stakers.
 ///
-/// ListTypeData::new_list only returns an Err when max would be size is
-/// greater than 1 MiB, or if the type depth is greater than 32. Our type
-/// depth is 1 and the max size is well 148 * 100 + 6, well under 1 MiB. We
-/// also have a test that exercises this path so we know that this won't
-/// panic in production.
+/// ListTypeData::new_list only returns an Err when max size of a value
+/// with this type could be greater than 1 MiB, or if the type depth is
+/// greater than 32. Our type depth is 1 and the max size is 148 * 100
+/// + 6, well under 1 MiB. We also have a test that exercises this path so
+/// we know that this won't panic in production.
 const LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
     ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH as u32).unwrap()
 });
@@ -69,8 +69,7 @@ pub struct StacksTxPostConditions {
     pub post_conditions: Vec<TransactionPostCondition>,
 }
 
-/// A trait to ease construction of a StacksTransaction making sBTC related
-/// contract calls.
+/// A trait to ease construction of a contract call StacksTransaction.
 pub trait AsContractCall {
     /// The name of the clarity smart contract that relates to this struct.
     const CONTRACT_NAME: &'static str;

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -139,3 +139,23 @@ impl AsContractCall for ProcessRewardClaimsBatch {
         ]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::types::PrincipalData;
+
+    use super::*;
+
+    #[test]
+    fn process_reward_claims_contract_call_creation() {
+        // This is to check that this function doesn't implicitly panic. If
+        // it doesn't panic now, it can never panic at runtime.
+        let call = ProcessRewardClaimsBatch {
+            signer_manager: QualifiedContractIdentifier::transient(),
+            stakers: vec![PrincipalData::from(StacksAddress::burn_address(false))],
+            deployer: StacksAddress::burn_address(false),
+        };
+
+        let _ = call.as_contract_call();
+    }
+}

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -20,16 +20,18 @@ use clarity::vm::types::StandardPrincipalData;
 use clarity::vm::types::TraitIdentifier;
 use clarity::vm::types::TypeSignature;
 
-use crate::stacks::reward_claim_registry::PROCESS_REWARD_CLAIMS_MAX_STAKERS;
+use crate::stacks::reward_claim_registry::MAX_STAKERS_LENGTH;
 use crate::stacks::reward_claim_registry::ProcessRewardClaimsBatch;
-
-const MAX_STAKERS_LENGTH: u32 = PROCESS_REWARD_CLAIMS_MAX_STAKERS as u32;
 
 /// The type signature for the list of 100 stakers.
 ///
-/// ListTypeData::new_list only returns an Err when max_len is greater than MiB
+/// ListTypeData::new_list only returns an Err when max would be size is
+/// greater than 1 MiB, or if the type depth is greater than 32. Our type
+/// depth is 1 and the max size is well 148 * 100 + 6, well under 1 MiB. We
+/// also have a test that exercises this path so we know that this won't
+/// panic in production.
 const LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
-    ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH).unwrap()
+    ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH as u32).unwrap()
 });
 
 /// The name of the trait that signer managers must implement.
@@ -55,10 +57,6 @@ fn make_trait_identifier(deployer: StacksAddress) -> TraitIdentifier {
 ///
 /// # Note
 ///
-/// * It's unlikely that this will be necessary since the signers control
-///   the contract to begin with, we implicitly trust it.
-/// * We cannot enforce any conditions on the destination of any sBTC, just
-///   the source and the amount.
 /// * SIP-005 describes the post conditions, including its limitations, and
 ///   can be found here
 ///   https://github.com/stacksgov/sips/blob/main/sips/sip-005/sip-005-blocks-and-transactions.md#transaction-post-conditions

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -25,20 +25,20 @@ use crate::stacks::reward_claim_registry::ProcessRewardClaimsBatch;
 
 /// The type signature for the list of 100 stakers.
 ///
-/// ListTypeData::new_list only returns an Err when max size of a value
-/// with this type could be greater than 1 MiB, or if the type depth is
-/// greater than 32. Our type depth is 1 and the max size is 148 * 100
-/// + 6, well under 1 MiB. We also have a test that exercises this path so
-/// we know that this won't panic in production.
-const LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
+/// ListTypeData::new_list only returns an Err when max size of the type
+/// could be greater than 1 MiB, or if the type depth is greater than 32.
+/// Our type depth is 1 and the max size is 148 * 100 + 6 bytes, well under
+/// 1 MiB. We also have a test that exercises this path so we know that
+/// this won't panic in production.
+static LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
     ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH as u32).unwrap()
 });
 
 /// The name of the trait that signer managers must implement.
-const REWARD_CLAIM_TRAIT_NAME: &'static str = "reward-claim-signer-manager-trait";
+const REWARD_CLAIM_TRAIT_NAME: &str = "reward-claim-signer-manager-trait";
 
 /// The name of the contract that contains the signer manager trait.
-const REWARD_CLAIM_TRAIT_CONTRACT: &'static str = "reward-claim-traits";
+const REWARD_CLAIM_TRAIT_CONTRACT: &str = "reward-claim-traits";
 
 /// This function creates a Trait identifier for the
 /// [`REWARD_CLAIM_TRAIT_NAME`] trait, once we know the issuer/deployer.
@@ -46,8 +46,12 @@ fn make_trait_identifier(deployer: StacksAddress) -> TraitIdentifier {
     TraitIdentifier {
         name: ClarityName::from(REWARD_CLAIM_TRAIT_NAME),
         contract_identifier: QualifiedContractIdentifier {
-            name: ContractName::try_from(REWARD_CLAIM_TRAIT_CONTRACT).unwrap(),
             issuer: StandardPrincipalData::from(deployer),
+            // The following From::from call is more dangerous than it
+            // appears. Under the hood it calls its TryFrom::try_from
+            // implementation and then unwrap them. We check that this
+            // is fine in our test.
+            name: ContractName::from(REWARD_CLAIM_TRAIT_CONTRACT),
         },
     }
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/48

## Changes

* Copied code over for constructing the payload of a Stacks transaction.
* Implemented functionality for constructing `process-reward-claims` contract call payload.
* Modified the expected return type of `get-pending-claims` to expect the signer manager to be a `QualifiedContractIdentifier`.

## Testing Information

Not much, yet. This new code is almost entirely unused.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
