### PR TITLE
feat: process reward claims via the registry

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,6 @@ use crate::config::Settings;
 use crate::error::Error;
 use crate::stacks::node::StacksClient;
 use crate::stacks::registry::DepositAddressRegistry;
-use crate::stacks::wallet::StacksWallet;
 use crate::storage::memory::{SharedStore, Store};
 
 /// Application context
@@ -59,27 +58,6 @@ impl TryFrom<&Settings> for Context {
 }
 
 impl Context {
-    /// Construct a Stacks wallet given the information in the config.
-    ///
-    /// # Note
-    ///
-    /// This function reaches out to the stacks node to get the current
-    /// chain ID.
-    pub async fn wallet(&self) -> Result<StacksWallet, Error> {
-        let config = &self.settings;
-        let Some(claims) = config.reward_claims.as_ref() else {
-            return Err(Error::MissingRewardClaimsConfig);
-        };
-        let Some(stacks) = config.stacks.as_ref() else {
-            return Err(Error::MissingStacksConfig);
-        };
-
-        // Let's go and get the current chain id.
-        let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
-        let info = client.get_node_info().await?;
-        Ok(StacksWallet::new(claims.private_key, info.chain_id, 0))
-    }
-
     /// Get a reference to the Bitcoin client
     pub fn bitcoin_client(&self) -> &BitcoinCoreClient {
         &self.bitcoin_client

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -57,7 +57,7 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
             tracing::warn!(%error, "error processing pending reward claims");
         }
 
-        if let Err(error) = process_pending_settlements(&chain_tip).await {
+        if let Err(error) = process_pending_settlements(&context, &chain_tip).await {
             tracing::warn!(%error, "error processing pending settlements");
         }
     }
@@ -114,7 +114,7 @@ async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Resul
 /// 2. Submits a settle-pending-withdrawals contract call for each batch of
 ///    settlements, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
-async fn process_pending_settlements(chain_tip: &BlockRef) -> Result<(), Error> {
+async fn process_pending_settlements(_: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
     // TODO(#40/#42): fetch pending settlements and submit settle-pending-withdrawals.
     tracing::debug!(%chain_tip, "reward settlement processing not yet implemented");
     Ok(())
@@ -124,9 +124,9 @@ async fn process_pending_settlements(chain_tip: &BlockRef) -> Result<(), Error> 
 #[derive(Debug)]
 pub struct RewardClaimState {
     /// The reward-claims registry
-    pub registry: RewardClaimRegistry,
+    registry: RewardClaimRegistry,
     /// A wallet for signing Stacks transactions
-    pub wallet: StacksWallet,
+    wallet: StacksWallet,
 }
 
 impl RewardClaimState {

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -8,19 +8,21 @@
 //! Run via [`crate::dispatch::run_on_chain_tips`] alongside deposit
 //! monitoring (see `main`).
 
-use std::sync::Arc;
-
 use tokio::sync::mpsc;
 
 use crate::bitcoin::BlockRef;
+use crate::config::Settings;
 use crate::context::Context;
 use crate::error::Error;
-use crate::stacks::node::{StacksClient, SubmitTxResponse};
+use crate::stacks::node::StacksClient;
+use crate::stacks::node::SubmitTxResponse;
 use crate::stacks::reward_claim_registry::RewardClaimRegistry;
 use crate::stacks::transaction::AsContractCall as _;
+use crate::stacks::wallet::StacksWallet;
 
 /// The transaction fee for all contract call transactions against the
 /// registry.
+/// TODO: remove and fetch the market fee rate from the node.
 const TX_FEE: u64 = 100000;
 
 /// The loop for processing reward claims that runs whenever a new Bitcoin
@@ -31,12 +33,31 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
         return;
     }
 
+    let state = match RewardClaimState::new(context.settings()).await {
+        Ok(claims) => claims,
+        Err(error) => {
+            tracing::error!(%error, "failed to initialize reward claims process");
+            return;
+        }
+    };
+
     while let Some(chain_tip) = rx.recv().await {
-        if let Err(error) = process_pending_claims(&context, &chain_tip).await {
+        // We update the wallet nonce before constucting any transactions.
+        // There is a risk that we have transactions in the mempool so
+        // using the fetched nonce will lead to an RBF attempt. This
+        // attempt could fail, because the proposed fee could be too low.
+        // However, with ~10 average bitcoin blocks and prompt stacks
+        // confirmations, this should rarely be an issue.
+        if let Err(error) = state.update_wallet_nonce().await {
+            tracing::warn!(%error, "failed to update wallet nonce");
+            continue;
+        }
+
+        if let Err(error) = process_claims(&state, &chain_tip).await {
             tracing::warn!(%error, "error processing pending reward claims");
         }
 
-        if let Err(error) = process_pending_settlements(&context, &chain_tip).await {
+        if let Err(error) = process_pending_settlements(&chain_tip).await {
             tracing::warn!(%error, "error processing pending settlements");
         }
     }
@@ -51,39 +72,32 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
 /// 2. Submits a process-reward-claims contract call for each batch of
 ///    claims, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
-async fn process_pending_claims(context: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
-    let settings = context.settings();
-    let Some(registry_config) = settings.reward_claims.as_ref() else {
-        tracing::info!("reward claims are not configured, skipping");
+async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Result<(), Error> {
+    let batches = state.registry.get_pending_claim_batches().await?;
+    if batches.is_empty() {
+        tracing::debug!(%chain_tip, "no pending reward claims");
         return Ok(());
-    };
-
-    let client = Arc::new(StacksClient::try_from(settings)?);
-
-    let registry =
-        RewardClaimRegistry::new(registry_config.claims_contract.clone(), client.clone());
-    let batches = registry.get_pending_claim_batches().await?;
-
-    let wallet = context.wallet().await?;
-    let account = client.get_account(wallet.address()).await?;
-    wallet.set_nonce(account.nonce);
+    }
 
     for batch in batches {
         let payload = batch.tx_payload();
-        let tx = wallet.sign_tx(payload, TX_FEE);
+        let tx = state.wallet.sign_tx(payload, TX_FEE);
 
-        match client.submit_tx(&tx).await {
+        match state.client().submit_tx(&tx).await {
             Ok(SubmitTxResponse::Acceptance(txid)) => {
-                tracing::debug!(%txid, "submitted process-reward-claims batch")
+                tracing::debug!(%txid, "submitted process-reward-claims batch");
             }
             Ok(SubmitTxResponse::Rejection(error)) => {
-                tracing::warn!(%error, "failed to submit process-reward-claims batch")
+                tracing::warn!(%error, "failed to submit process-reward-claims batch");
+                state.decrement_wallet_nonce();
             }
-            Err(error) => tracing::warn!(%error, "failed to submit process-reward-claims batch"),
-        };
+            Err(error) => {
+                tracing::warn!(%error, "failed to submit process-reward-claims batch");
+            }
+        }
     }
 
-    tracing::debug!(%chain_tip, "submitted process-reward-claims batches");
+    tracing::debug!(%chain_tip, "finished process-reward-claims submissions");
     Ok(())
 }
 
@@ -96,8 +110,62 @@ async fn process_pending_claims(context: &Context, chain_tip: &BlockRef) -> Resu
 /// 2. Submits a settle-pending-withdrawals contract call for each batch of
 ///    settlements, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
-async fn process_pending_settlements(_: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
+async fn process_pending_settlements(chain_tip: &BlockRef) -> Result<(), Error> {
     // TODO(#40/#42): fetch pending settlements and submit settle-pending-withdrawals.
     tracing::debug!(%chain_tip, "reward settlement processing not yet implemented");
     Ok(())
+}
+
+/// The context needed for the reward-claims loop.
+#[derive(Debug)]
+pub struct RewardClaimState {
+    /// The reward-claims registry
+    pub registry: RewardClaimRegistry,
+    /// A wallet for signing Stacks transactions
+    pub wallet: StacksWallet,
+}
+
+impl RewardClaimState {
+    /// Construct a Stacks wallet given the information in the config.
+    ///
+    /// # Note
+    ///
+    /// This function reaches out to the stacks node to get the current
+    /// chain ID.
+    pub async fn new(settings: &Settings) -> Result<Self, Error> {
+        let Some(config) = settings.reward_claims.clone() else {
+            return Err(Error::MissingRewardClaimsConfig);
+        };
+        let Some(stacks) = settings.stacks.as_ref() else {
+            return Err(Error::MissingStacksConfig);
+        };
+
+        // Let's go and get the current chain id.
+        let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
+        let info = client.get_node_info().await?;
+        let wallet = StacksWallet::new(config.private_key, info.chain_id, 0);
+
+        let registry = RewardClaimRegistry::new(config.claims_contract, client);
+
+        Ok(Self { registry, wallet })
+    }
+
+    /// Update the account nonce for the wallet.
+    pub async fn update_wallet_nonce(&self) -> Result<(), Error> {
+        let address = self.wallet.address();
+        let account = self.registry.client().get_account(address).await?;
+        self.wallet.set_nonce(account.nonce);
+        Ok(())
+    }
+
+    /// Decrement the wallet nonce by 1.
+    pub fn decrement_wallet_nonce(&self) {
+        let nonce = self.wallet.get_nonce();
+        self.wallet.set_nonce(nonce.saturating_sub(1));
+    }
+
+    /// Get a reference to the client.
+    pub fn client(&self) -> &StacksClient {
+        self.registry.client()
+    }
 }

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -8,11 +8,20 @@
 //! Run via [`crate::dispatch::run_on_chain_tips`] alongside deposit
 //! monitoring (see `main`).
 
+use std::sync::Arc;
+
 use tokio::sync::mpsc;
 
 use crate::bitcoin::BlockRef;
 use crate::context::Context;
 use crate::error::Error;
+use crate::stacks::node::{StacksClient, SubmitTxResponse};
+use crate::stacks::reward_claim_registry::RewardClaimRegistry;
+use crate::stacks::transaction::AsContractCall as _;
+
+/// The transaction fee for all contract call transactions against the
+/// registry.
+const TX_FEE: u64 = 100000;
 
 /// The loop for processing reward claims that runs whenever a new Bitcoin
 /// block is detected.
@@ -42,9 +51,39 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
 /// 2. Submits a process-reward-claims contract call for each batch of
 ///    claims, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
-async fn process_pending_claims(_: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
-    // TODO(#41/#42): fetch pending claims and submit process-reward-claims.
-    tracing::debug!(%chain_tip, "reward claim processing not yet implemented");
+async fn process_pending_claims(context: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
+    let settings = context.settings();
+    let Some(registry_config) = settings.reward_claims.as_ref() else {
+        tracing::info!("reward claims are not configured, skipping");
+        return Ok(());
+    };
+
+    let client = Arc::new(StacksClient::try_from(settings)?);
+
+    let registry =
+        RewardClaimRegistry::new(registry_config.claims_contract.clone(), client.clone());
+    let batches = registry.get_pending_claim_batches().await?;
+
+    let wallet = context.wallet().await?;
+    let account = client.get_account(wallet.address()).await?;
+    wallet.set_nonce(account.nonce);
+
+    for batch in batches {
+        let payload = batch.tx_payload();
+        let tx = wallet.sign_tx(payload, TX_FEE);
+
+        match client.submit_tx(&tx).await {
+            Ok(SubmitTxResponse::Acceptance(txid)) => {
+                tracing::debug!(%txid, "submitted process-reward-claims batch")
+            }
+            Ok(SubmitTxResponse::Rejection(error)) => {
+                tracing::warn!(%error, "failed to submit process-reward-claims batch")
+            }
+            Err(error) => tracing::warn!(%error, "failed to submit process-reward-claims batch"),
+        };
+    }
+
+    tracing::debug!(%chain_tip, "submitted process-reward-claims batches");
     Ok(())
 }
 

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -86,12 +86,16 @@ async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Resul
         match state.client().submit_tx(&tx).await {
             Ok(SubmitTxResponse::Acceptance(txid)) => {
                 tracing::debug!(%txid, "submitted process-reward-claims batch");
+                state.increment_wallet_nonce();
             }
             Ok(SubmitTxResponse::Rejection(error)) => {
                 tracing::warn!(%error, "failed to submit process-reward-claims batch");
-                state.decrement_wallet_nonce();
             }
             Err(error) => {
+                // It could be the case that we broadcast the transaction
+                // to the node and it was rejeected by then we got an error
+                // here anyway. I don't see a clean way to handle this
+                // without adding another issue.
                 tracing::warn!(%error, "failed to submit process-reward-claims batch");
             }
         }
@@ -158,10 +162,10 @@ impl RewardClaimState {
         Ok(())
     }
 
-    /// Decrement the wallet nonce by 1.
-    pub fn decrement_wallet_nonce(&self) {
+    /// Increment the wallet nonce by 1.
+    pub fn increment_wallet_nonce(&self) {
         let nonce = self.wallet.get_nonce();
-        self.wallet.set_nonce(nonce.saturating_sub(1));
+        self.wallet.set_nonce(nonce.saturating_add(1));
     }
 
     /// Get a reference to the client.

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -100,7 +100,7 @@ async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Resul
             }
             Err(error) => {
                 // It could be the case that we broadcast the transaction
-                // to the node and it was rejeected by then we got an error
+                // to the node and it was rejected by then we got an error
                 // here anyway. I don't see a clean way to handle this
                 // without adding another issue.
                 tracing::warn!(%error, "failed to submit process-reward-claims batch");

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -9,6 +9,7 @@
 //! monitoring (see `main`).
 
 use tokio::sync::mpsc;
+use tracing::instrument;
 
 use crate::bitcoin::BlockRef;
 use crate::config::Settings;
@@ -72,20 +73,26 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
 /// 2. Submits a process-reward-claims contract call for each batch of
 ///    claims, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
+#[instrument(skip(state))]
 async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Result<(), Error> {
     let batches = state.registry.get_pending_claim_batches().await?;
     if batches.is_empty() {
-        tracing::debug!(%chain_tip, "no pending reward claims");
+        tracing::info!("no pending reward claims");
         return Ok(());
     }
 
     for batch in batches {
+        tracing::info!(
+            "signer_manager" = %batch.signer_manager(),
+            "num_stakers" = %batch.stakers().len(),
+            "processing process-reward-claims batch",
+        );
         let payload = batch.tx_payload();
         let tx = state.wallet.sign_tx(payload, TX_FEE);
 
         match state.client().submit_tx(&tx).await {
             Ok(SubmitTxResponse::Acceptance(txid)) => {
-                tracing::debug!(%txid, "submitted process-reward-claims batch");
+                tracing::info!(%txid, "submitted process-reward-claims batch");
                 state.increment_wallet_nonce();
             }
             Ok(SubmitTxResponse::Rejection(error)) => {
@@ -164,8 +171,7 @@ impl RewardClaimState {
 
     /// Increment the wallet nonce by 1.
     pub fn increment_wallet_nonce(&self) {
-        let nonce = self.wallet.get_nonce();
-        self.wallet.set_nonce(nonce.saturating_add(1));
+        self.wallet.increment_nonce();
     }
 
     /// Get a reference to the client.

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -4,11 +4,16 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use bitcoin::{PublicKey, XOnlyPublicKey};
+use blockstack_lib::burnchains::Txid;
+use blockstack_lib::chainstate::stacks::StacksTransaction;
+use blockstack_lib::codec::StacksMessageCodec as _;
 use clarity::types::chainstate::BlockHeaderHash;
 use clarity::types::chainstate::ConsensusHash;
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::types::{BuffData, SequenceData};
 use clarity::vm::{ClarityName, ContractName, Value};
+use reqwest::header::CONTENT_LENGTH;
+use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Deserializer};
 use url::Url;
 
@@ -66,6 +71,48 @@ pub struct AccountInfo {
     pub unlock_height: u64,
     /// The next nonce for the account.
     pub nonce: u64,
+}
+
+/// The details of a rejected transaction
+///
+/// The fields match the JSON fields returned from a Stacks node and are
+/// defined in:
+/// https://github.com/stacks-network/stacks-core/blob/2.5.0.0.5/docs/rpc-endpoints.md
+#[derive(Debug, Deserialize)]
+pub struct TxRejection {
+    /// The error message. It should always be the string "transaction
+    /// rejection".
+    pub error: String,
+    /// The reason code for the rejection.
+    pub reason: String,
+    /// More details about the reason for the rejection.
+    pub reason_data: Option<serde_json::Value>,
+    /// The transaction ID of the rejected transaction.
+    pub txid: Txid,
+}
+
+impl std::fmt::Display for TxRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "transaction rejected from the mempool: {}", self.reason)
+    }
+}
+
+impl std::error::Error for TxRejection {}
+
+/// The response from a POST /v2/transactions request.
+///
+/// The stacks node returns three types of responses, either:
+/// 1. A 200 status hex encoded txid in the response body (on acceptance)
+/// 2. A 400 status with a JSON object body (on rejection),
+/// 3. A 400/500 status string message about some other error (such as
+///    using an unsupported address mode).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum SubmitTxResponse {
+    /// The transaction ID for the submitted transaction.
+    Acceptance(Txid),
+    /// The response when the transaction is rejected from the node.
+    Rejection(TxRejection),
 }
 
 /// Subset of the response from `GET /v2/info`.
@@ -278,6 +325,40 @@ impl StacksClient {
             .error_for_status()
             .map_err(Error::StacksNodeResponse)?
             .json::<NodeInfo>()
+            .await
+            .map_err(Error::UnexpectedStacksResponse)
+    }
+
+    /// Submit a transaction to a Stacks node.
+    ///
+    /// This is done by making a POST /v2/transactions request to a Stacks
+    /// node. That endpoint supports two different content-types in the
+    /// request body: JSON, and an octet-stream. This function always sends
+    /// the raw transaction bytes as an octet-stream.
+    #[tracing::instrument(skip_all)]
+    pub async fn submit_tx(&self, tx: &StacksTransaction) -> Result<SubmitTxResponse, Error> {
+        let path = "/v2/transactions";
+        let url = self
+            .endpoint
+            .join(path)
+            .map_err(|err| Error::PathJoin(err, self.endpoint.clone(), Cow::Borrowed(path)))?;
+
+        tracing::debug!(txid = %tx.txid(), "submitting transaction to the stacks node");
+        let body = tx.serialize_to_vec();
+
+        let response: reqwest::Response = self
+            .client
+            .post(url)
+            .timeout(REQUEST_TIMEOUT)
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .header(CONTENT_LENGTH, body.len())
+            .body(body)
+            .send()
+            .await
+            .map_err(Error::StacksNodeRequest)?;
+
+        response
+            .json()
             .await
             .map_err(Error::UnexpectedStacksResponse)
     }

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -202,29 +202,35 @@ impl RewardClaimRegistry {
     /// at most [`MAX_STAKERS_LENGTH`] stakers per batch.
     pub async fn get_pending_claim_batches(&self) -> Result<Vec<RewardClaimsBatch>, Error> {
         let claims = self.get_all_pending_claims().await?;
-
-        let mut groups: HashMap<QualifiedContractIdentifier, Vec<PrincipalData>> = HashMap::new();
-
-        for claim in claims {
-            groups
-                .entry(claim.signer_manager)
-                .or_default()
-                .push(claim.staker);
-        }
-
-        let mut batches = Vec::new();
-        for (signer_manager, stakers) in groups {
-            for chunk in stakers.chunks(MAX_STAKERS_LENGTH) {
-                batches.push(RewardClaimsBatch {
-                    signer_manager: signer_manager.clone(),
-                    stakers: chunk.to_vec(),
-                    deployer: self.deployer.clone(),
-                });
-            }
-        }
-
-        Ok(batches)
+        Ok(batch_claims(claims, &self.deployer))
     }
+}
+
+/// Group pending claims by signer-manager and split into contract-call batches.
+///
+/// Each batch has at most [`MAX_STAKERS_LENGTH`] stakers.
+fn batch_claims(claims: Vec<PendingClaim>, deployer: &StacksAddress) -> Vec<RewardClaimsBatch> {
+    let mut groups: HashMap<QualifiedContractIdentifier, Vec<PrincipalData>> = HashMap::new();
+
+    for claim in claims {
+        groups
+            .entry(claim.signer_manager)
+            .or_default()
+            .push(claim.staker);
+    }
+
+    let mut batches = Vec::new();
+    for (signer_manager, stakers) in groups {
+        for chunk in stakers.chunks(MAX_STAKERS_LENGTH) {
+            batches.push(RewardClaimsBatch {
+                signer_manager: signer_manager.clone(),
+                stakers: chunk.to_vec(),
+                deployer: deployer.clone(),
+            });
+        }
+    }
+
+    batches
 }
 
 impl TryFrom<ClarityValue> for RegistrationKey {
@@ -359,6 +365,20 @@ mod tests {
         );
         ClarityValue::okay(page).unwrap()
     }
+
+    fn claim(
+        signer_manager: &QualifiedContractIdentifier,
+        staker: PrincipalData,
+        reward_cycle: u128,
+    ) -> PendingClaim {
+        PendingClaim {
+            signer_manager: signer_manager.clone(),
+            staker,
+            bond_index: None,
+            reward_cycle,
+        }
+    }
+
 
     #[tokio::test]
     async fn get_pending_claims_works_without_cursor() {
@@ -598,5 +618,68 @@ mod tests {
         assert_eq!(result, vec![pending]);
         empty_with_next.assert();
         pending_then_done.assert();
+    }
+
+    #[test]
+    fn batch_pending_claims_empty() {
+        assert!(batch_claims(vec![], &StacksAddress::burn_address(false)).is_empty());
+    }
+
+    #[test]
+    fn batch_pending_claims_groups_by_signer_manager() {
+        let sm_a = QualifiedContractIdentifier::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager").unwrap();
+        let sm_b = QualifiedContractIdentifier::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.other-manager").unwrap();
+        let staker1 = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
+        let staker2 = PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap();
+        let staker3 = PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.staker-3").unwrap();
+
+        let claims = vec![
+            claim(&sm_a, staker1.clone(), 1),
+            claim(&sm_b, staker2.clone(), 2),
+            claim(&sm_a, staker3.clone(), 3),
+        ];
+
+        let batches = batch_claims(claims, &StacksAddress::burn_address(false));
+        assert_eq!(batches.len(), 2);
+
+        let batch_a = batches
+            .iter()
+            .find(|batch| batch.signer_manager() == &sm_a)
+            .expect("batch for signer-manager A");
+        let batch_b = batches
+            .iter()
+            .find(|batch| batch.signer_manager() == &sm_b)
+            .expect("batch for signer-manager B");
+
+        assert_eq!(batch_a.stakers(), &[staker1, staker3]);
+        assert_eq!(batch_b.stakers(), &[staker2]);
+        assert_eq!(batch_a.deployer(), &StacksAddress::burn_address(false));
+        assert_eq!(batch_b.deployer(), &StacksAddress::burn_address(false));
+    }
+
+    #[test]
+    fn batch_pending_claims_chunks_at_max_stakers() {
+        let sm = QualifiedContractIdentifier::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager").unwrap();
+        let claims: Vec<_> = (0..=MAX_STAKERS_LENGTH)
+            .map(|i| {
+                claim(
+                    &sm,
+                    PrincipalData::parse(&format!("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.s{i}")).unwrap(),
+                    i as u128,
+                )
+            })
+            .collect();
+
+        let batches = batch_claims(claims.clone(), &StacksAddress::burn_address(false));
+        assert_eq!(batches.len(), 2);
+        assert!(batches.iter().all(|batch| batch.signer_manager() == &sm));
+        assert_eq!(batches[0].stakers().len(), MAX_STAKERS_LENGTH);
+        assert_eq!(batches[1].stakers().len(), 1);
+        assert_eq!(batches[0].stakers()[0], claims[0].staker);
+        assert_eq!(
+            batches[0].stakers()[MAX_STAKERS_LENGTH - 1],
+            claims[MAX_STAKERS_LENGTH - 1].staker
+        );
+        assert_eq!(batches[1].stakers()[0], claims[MAX_STAKERS_LENGTH].staker);
     }
 }

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -187,8 +187,8 @@ impl RewardClaimRegistry {
         let mut cursor: Option<RegistrationKey> = None;
 
         loop {
-            let mut page = self.get_pending_claims(cursor.as_ref()).await?;
-            all.append(&mut page.claims);
+            let page = self.get_pending_claims(cursor.as_ref()).await?;
+            all.extend(page.claims);
             match page.next {
                 Some(next) => cursor = Some(next),
                 None => break,

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -82,7 +82,7 @@ impl RewardClaimsBatch {
     pub fn dummy() -> Self {
         Self {
             signer_manager: QualifiedContractIdentifier::transient(),
-            stakers: vec![PrincipalData::from(StacksAddress::burn_address(false))].to_vec(),
+            stakers: vec![PrincipalData::from(StacksAddress::burn_address(false))],
             deployer: StacksAddress::burn_address(false),
         }
     }
@@ -379,7 +379,6 @@ mod tests {
         }
     }
 
-
     #[tokio::test]
     async fn get_pending_claims_works_without_cursor() {
         let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
@@ -627,11 +626,18 @@ mod tests {
 
     #[test]
     fn batch_pending_claims_groups_by_signer_manager() {
-        let sm_a = QualifiedContractIdentifier::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager").unwrap();
-        let sm_b = QualifiedContractIdentifier::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.other-manager").unwrap();
+        let sm_a = QualifiedContractIdentifier::parse(
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
+        )
+        .unwrap();
+        let sm_b = QualifiedContractIdentifier::parse(
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.other-manager",
+        )
+        .unwrap();
         let staker1 = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
         let staker2 = PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap();
-        let staker3 = PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.staker-3").unwrap();
+        let staker3 =
+            PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.staker-3").unwrap();
 
         let claims = vec![
             claim(&sm_a, staker1.clone(), 1),
@@ -659,12 +665,18 @@ mod tests {
 
     #[test]
     fn batch_pending_claims_chunks_at_max_stakers() {
-        let sm = QualifiedContractIdentifier::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager").unwrap();
+        let sm = QualifiedContractIdentifier::parse(
+            "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
+        )
+        .unwrap();
         let claims: Vec<_> = (0..=MAX_STAKERS_LENGTH)
             .map(|i| {
                 claim(
                     &sm,
-                    PrincipalData::parse(&format!("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.s{i}")).unwrap(),
+                    PrincipalData::parse(&format!(
+                        "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.s{i}"
+                    ))
+                    .unwrap(),
                     i as u128,
                 )
             })

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -1,5 +1,8 @@
 //! Client for the on-chain reward claim registry.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::ClarityName;
 use clarity::vm::ContractName;
@@ -63,37 +66,63 @@ pub struct PendingClaimsPage {
 /// Arguments for one `process-reward-claims` contract call.
 ///
 /// All [`Self::stakers`] share [`Self::signer_manager`], and the list
-/// length is at most [`MAX_STAKERS_LENGTH`]. (TODO: enforce this at
-/// construction time)
+/// length is at most [`MAX_STAKERS_LENGTH`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProcessRewardClaimsBatch {
+pub struct RewardClaimsBatch {
     /// Signer-manager trait principal passed to `process-reward-claims`.
-    pub signer_manager: QualifiedContractIdentifier,
+    signer_manager: QualifiedContractIdentifier,
     /// Staker principals to claim for in this call (1..=100).
-    pub stakers: Vec<PrincipalData>,
+    stakers: Vec<PrincipalData>,
     /// The address that deployed the rewards claim registry.
-    pub deployer: StacksAddress,
+    deployer: StacksAddress,
+}
+
+impl RewardClaimsBatch {
+    /// Create a new dummy reward claims batch.
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        Self {
+            signer_manager: QualifiedContractIdentifier::transient(),
+            stakers: vec![PrincipalData::from(StacksAddress::burn_address(false))].to_vec(),
+            deployer: StacksAddress::burn_address(false),
+        }
+    }
+
+    /// The signer-manager principal passed to `process-reward-claims`.
+    pub fn signer_manager(&self) -> &QualifiedContractIdentifier {
+        &self.signer_manager
+    }
+
+    /// The stakers to claim for in this call.
+    pub fn stakers(&self) -> &[PrincipalData] {
+        &self.stakers
+    }
+
+    /// The address that deployed the rewards claim registry.
+    pub fn deployer(&self) -> &StacksAddress {
+        &self.deployer
+    }
 }
 
 /// Client for querying the on-chain reward claim registry contract.
 #[derive(Debug, Clone)]
 pub struct RewardClaimRegistry {
     /// The deployer of the registry smart contract.
-    contract_principal: StacksAddress,
+    deployer: StacksAddress,
     /// The name of the registry smart contract.
     contract_name: ContractName,
     /// The client used to make the requests.
-    client: StacksClient,
+    client: Arc<StacksClient>,
 }
 
 impl RewardClaimRegistry {
     /// Create a new reward claim registry client.
-    pub fn new(contract: QualifiedContractIdentifier, client: StacksClient) -> Self {
-        let contract_principal = contract.issuer.into();
+    pub fn new(contract: QualifiedContractIdentifier, client: Arc<StacksClient>) -> Self {
+        let deployer = contract.issuer.into();
 
         Self {
             contract_name: contract.name,
-            contract_principal,
+            deployer,
             client,
         }
     }
@@ -104,7 +133,7 @@ impl RewardClaimRegistry {
     /// linked list. To paginate, pass [`PendingClaimsPage::next`] from the
     /// previous page. `next == None` means the walk reached the tail; an
     /// empty `claims` list alone does not.
-    pub async fn get_pending_claims(
+    async fn get_pending_claims(
         &self,
         cursor: Option<&RegistrationKey>,
     ) -> Result<PendingClaimsPage, Error> {
@@ -131,10 +160,10 @@ impl RewardClaimRegistry {
         let result = self
             .client
             .call_read(
-                &self.contract_principal,
+                &self.deployer,
                 &self.contract_name,
                 &ClarityName::from("get-pending-claims"),
-                &self.contract_principal,
+                &self.deployer,
                 &[cursor_arg],
             )
             .await?;
@@ -148,15 +177,14 @@ impl RewardClaimRegistry {
 
     /// Fetch every pending claim by paging through `get-pending-claims`.
     ///
-    /// Continues while the page's `next` cursor is `Some`, including pages
-    /// that return no rows (ticks spent on non-pending registrations).
-    pub async fn get_all_pending_claims(&self) -> Result<Vec<PendingClaim>, Error> {
+    /// Continues while the page's `next` cursor is `Some`.
+    async fn get_all_pending_claims(&self) -> Result<Vec<PendingClaim>, Error> {
         let mut all = Vec::new();
         let mut cursor: Option<RegistrationKey> = None;
 
         loop {
-            let page = self.get_pending_claims(cursor.as_ref()).await?;
-            all.extend(page.claims);
+            let mut page = self.get_pending_claims(cursor.as_ref()).await?;
+            all.append(&mut page.claims);
             match page.next {
                 Some(next) => cursor = Some(next),
                 None => break,
@@ -164,6 +192,33 @@ impl RewardClaimRegistry {
         }
 
         Ok(all)
+    }
+
+    /// Get all pending claims, batched by signer manager, with chunks of
+    /// at most [`MAX_STAKERS_LENGTH`] stakers per batch.
+    pub async fn get_pending_claim_batches(&self) -> Result<Vec<RewardClaimsBatch>, Error> {
+        let claims = self.get_all_pending_claims().await?;
+
+        let mut groups: HashMap<QualifiedContractIdentifier, Vec<PrincipalData>> = HashMap::new();
+
+        for claim in claims {
+            groups
+                .entry(claim.signer_manager)
+                .or_default()
+                .push(claim.staker);
+        }
+
+        let mut batches = Vec::new();
+        for (signer_manager, stakers) in groups {
+            for chunk in stakers.chunks(MAX_STAKERS_LENGTH) {
+                batches.push(RewardClaimsBatch {
+                    signer_manager: signer_manager.clone(),
+                    stakers: chunk.to_vec(),
+                    deployer: self.deployer.clone(),
+                });
+            }
+        }
+        Ok(batches)
     }
 }
 
@@ -339,7 +394,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = Arc::new(StacksClient::new(client_url).unwrap());
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -407,7 +462,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = Arc::new(StacksClient::new(client_url).unwrap());
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -449,7 +504,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = Arc::new(StacksClient::new(client_url).unwrap());
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -523,7 +578,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = Arc::new(StacksClient::new(client_url).unwrap());
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -1,7 +1,6 @@
 //! Client for the on-chain reward claim registry.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use clarity::types::chainstate::StacksAddress;
 use clarity::vm::ClarityName;
@@ -112,12 +111,12 @@ pub struct RewardClaimRegistry {
     /// The name of the registry smart contract.
     contract_name: ContractName,
     /// The client used to make the requests.
-    client: Arc<StacksClient>,
+    client: StacksClient,
 }
 
 impl RewardClaimRegistry {
     /// Create a new reward claim registry client.
-    pub fn new(contract: QualifiedContractIdentifier, client: Arc<StacksClient>) -> Self {
+    pub fn new(contract: QualifiedContractIdentifier, client: StacksClient) -> Self {
         let deployer = contract.issuer.into();
 
         Self {
@@ -125,6 +124,11 @@ impl RewardClaimRegistry {
             deployer,
             client,
         }
+    }
+
+    /// Get a reference to the client.
+    pub fn client(&self) -> &StacksClient {
+        &self.client
     }
 
     /// Fetch a page of pending claims from the registry.
@@ -218,6 +222,7 @@ impl RewardClaimRegistry {
                 });
             }
         }
+
         Ok(batches)
     }
 }
@@ -394,7 +399,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = Arc::new(StacksClient::new(client_url).unwrap());
+        let client = StacksClient::new(client_url).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -462,7 +467,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = Arc::new(StacksClient::new(client_url).unwrap());
+        let client = StacksClient::new(client_url).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -504,7 +509,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = Arc::new(StacksClient::new(client_url).unwrap());
+        let client = StacksClient::new(client_url).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -578,7 +583,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = Arc::new(StacksClient::new(client_url).unwrap());
+        let client = StacksClient::new(client_url).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -21,7 +21,7 @@ use clarity::vm::types::TraitIdentifier;
 use clarity::vm::types::TypeSignature;
 
 use crate::stacks::reward_claim_registry::MAX_STAKERS_LENGTH;
-use crate::stacks::reward_claim_registry::ProcessRewardClaimsBatch;
+use crate::stacks::reward_claim_registry::RewardClaimsBatch;
 
 /// The type signature for the list of 100 stakers.
 ///
@@ -113,22 +113,22 @@ pub trait AsContractCall {
     }
 }
 
-impl AsContractCall for ProcessRewardClaimsBatch {
+impl AsContractCall for RewardClaimsBatch {
     /// The name of the clarity smart contract that relates to this struct.
     const CONTRACT_NAME: &'static str = "reward-claim-registry";
     /// The specific function name that relates to this struct.
     const FUNCTION_NAME: &'static str = "process-reward-claims";
     /// The stacks address that deployed the contract.
     fn deployer_address(&self) -> &StacksAddress {
-        &self.deployer
+        self.deployer()
     }
     /// The arguments to the clarity function.
     fn as_contract_args(&self) -> Vec<ClarityValue> {
         let callable = CallableData {
-            contract_identifier: self.signer_manager.clone(),
-            trait_identifier: Some(make_trait_identifier(self.deployer.clone())),
+            contract_identifier: self.signer_manager().clone(),
+            trait_identifier: Some(make_trait_identifier(self.deployer().clone())),
         };
-        let stakers = self.stakers.iter().cloned().map(ClarityValue::Principal);
+        let stakers = self.stakers().iter().cloned().map(ClarityValue::Principal);
         let stakers = ListData {
             data: stakers.collect(),
             type_signature: LIST_PRINCIPALS_SIGNATURE.clone(),
@@ -143,19 +143,13 @@ impl AsContractCall for ProcessRewardClaimsBatch {
 
 #[cfg(test)]
 mod tests {
-    use clarity::vm::types::PrincipalData;
-
     use super::*;
 
     #[test]
     fn process_reward_claims_contract_call_creation() {
         // This is to check that this function doesn't implicitly panic. If
         // it doesn't panic now, it can never panic at runtime.
-        let call = ProcessRewardClaimsBatch {
-            signer_manager: QualifiedContractIdentifier::transient(),
-            stakers: vec![PrincipalData::from(StacksAddress::burn_address(false))],
-            deployer: StacksAddress::burn_address(false),
-        };
+        let call = RewardClaimsBatch::dummy();
 
         let _ = call.as_contract_call();
     }

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -81,9 +81,9 @@ impl StacksWallet {
         self.nonce.store(value, Ordering::Relaxed);
     }
 
-    /// Set the next nonce to the provided value.
-    pub fn get_nonce(&self) -> u64 {
-        self.nonce.load(Ordering::Relaxed)
+    /// Increment the wallet nonce by 1.
+    pub fn increment_nonce(&self) {
+        self.nonce.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Build an unsigned single-sig spending condition and advance the local nonce.
@@ -92,7 +92,7 @@ impl StacksWallet {
     pub fn as_unsigned_tx_auth(&self, tx_fee: u64) -> SinglesigSpendingCondition {
         SinglesigSpendingCondition {
             signer: self.address.bytes().clone(),
-            nonce: self.get_nonce(),
+            nonce: self.nonce.load(Ordering::Relaxed),
             tx_fee,
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Compressed,
@@ -216,16 +216,16 @@ mod tests {
     }
 
     #[test]
-    fn as_unsigned_tx_auth_increments_nonce() {
+    fn as_unsigned_tx_auth_uses_current_nonce_without_incrementing() {
         let wallet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 7);
 
         let auth0 = wallet.as_unsigned_tx_auth(1000);
         assert_eq!(auth0.nonce, 7);
-        assert_eq!(wallet.nonce(), 8);
+        assert_eq!(wallet.nonce(), 7);
 
         let auth1 = wallet.as_unsigned_tx_auth(1000);
-        assert_eq!(auth1.nonce, 8);
-        assert_eq!(wallet.nonce(), 9);
+        assert_eq!(auth1.nonce, 7);
+        assert_eq!(wallet.nonce(), 7);
     }
 
     #[test]
@@ -236,7 +236,7 @@ mod tests {
         let tx = wallet.sign_tx(payload, 1000);
         assert!(tx.verify().is_ok());
         assert_eq!(tx.chain_id, CHAIN_ID_TESTNET);
-        assert_eq!(wallet.nonce(), 1);
+        assert_eq!(wallet.nonce(), 0);
     }
 
     #[test]
@@ -247,7 +247,18 @@ mod tests {
 
         let auth = wallet.as_unsigned_tx_auth(1);
         assert_eq!(auth.nonce, 42);
-        assert_eq!(wallet.nonce(), 43);
+        assert_eq!(wallet.nonce(), 42);
+    }
+
+    #[test]
+    fn increment_nonce_advances_counter() {
+        let wallet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 7);
+        wallet.increment_nonce();
+        assert_eq!(wallet.nonce(), 8);
+
+        let auth = wallet.as_unsigned_tx_auth(1000);
+        assert_eq!(auth.nonce, 8);
+        assert_eq!(wallet.nonce(), 8);
     }
 
     #[test]

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -76,9 +76,14 @@ impl StacksWallet {
         self.chain_id == CHAIN_ID_MAINNET
     }
 
-    /// Set the next nonce to the provided value (typically from `get_account`).
+    /// Set the next nonce to the provided value.
     pub fn set_nonce(&self, value: u64) {
         self.nonce.store(value, Ordering::Relaxed);
+    }
+
+    /// Get the next nonce for the wallet.
+    pub fn get_nonce(&self) -> u64 {
+        self.nonce.load(Ordering::Relaxed)
     }
 
     /// Build an unsigned single-sig spending condition and advance the local nonce.

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -25,14 +25,11 @@ use secp256k1::ecdsa::RecoverableSignature;
 
 /// A single-sig Stacks wallet that tracks a local nonce counter.
 ///
-/// The nonce starts at whatever value is passed to [`StacksWallet::new`] (typically `0`)
-/// and is incremented when building transaction auth via [`StacksWallet::as_unsigned_tx_auth`].
-/// Callers must refresh the nonce from the node with [`StacksWallet::set_nonce`] (after
-/// `get_account`) before submitting transactions.
+/// The nonce starts at whatever value is passed to [`StacksWallet::new`]
+/// and must be manually incremented or set.
 ///
-/// `chain_id` is the exact value from the stacks node's `/v2/info` `network_id` field and is
-/// written into signed transactions. Address version bytes only depend on whether that value
-/// equals [`CHAIN_ID_MAINNET`].
+/// The `chain_id` should be the exact value from the stacks node's
+/// `/v2/info` `network_id` field.
 #[derive(Debug)]
 pub struct StacksWallet {
     /// Secp256k1 private key used to sign transactions.
@@ -86,9 +83,10 @@ impl StacksWallet {
         self.nonce.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Build an unsigned single-sig spending condition and advance the local nonce.
+    /// Build an unsigned single-sig spending condition.
     ///
-    /// The returned spending condition has a fee and nonce set, but an empty signature.
+    /// The returned spending condition has a fee and nonce set, but an
+    /// empty signature.
     pub fn as_unsigned_tx_auth(&self, tx_fee: u64) -> SinglesigSpendingCondition {
         SinglesigSpendingCondition {
             signer: self.address.bytes().clone(),
@@ -101,8 +99,6 @@ impl StacksWallet {
     }
 
     /// Build and sign a Stacks transaction for the given payload.
-    ///
-    /// This advances the local nonce via [`StacksWallet::as_unsigned_tx_auth`].
     pub fn sign_tx(&self, payload: TransactionPayload, tx_fee: u64) -> StacksTransaction {
         use TransactionSpendingCondition::Singlesig;
 

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -81,7 +81,7 @@ impl StacksWallet {
         self.nonce.store(value, Ordering::Relaxed);
     }
 
-    /// Get the next nonce for the wallet.
+    /// Set the next nonce to the provided value.
     pub fn get_nonce(&self) -> u64 {
         self.nonce.load(Ordering::Relaxed)
     }
@@ -92,7 +92,7 @@ impl StacksWallet {
     pub fn as_unsigned_tx_auth(&self, tx_fee: u64) -> SinglesigSpendingCondition {
         SinglesigSpendingCondition {
             signer: self.address.bytes().clone(),
-            nonce: self.nonce.fetch_add(1, Ordering::Relaxed),
+            nonce: self.get_nonce(),
             tx_fee,
             hash_mode: SinglesigHashMode::P2PKH,
             key_encoding: TransactionPublicKeyEncoding::Compressed,


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/41 and closes https://github.com/stx-labs/spox/issues/42

## Changes

* Add code that batches pending rewards by signer-manager into groups of at most 100 stakers.
* Add code for submitting contract calls. This was copied over from the sbtc repo.
* Wired everything up to make actual contract calls.
* Require nonces to be manually incremented.

## Testing Information

Not much, yet. This new code is almost entirely unused.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
