### PR TITLE
feat: add chain tip parameter to read only calls

### DIFF
--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -10,6 +10,7 @@ use blockstack_lib::codec::StacksMessageCodec as _;
 use clarity::types::chainstate::BlockHeaderHash;
 use clarity::types::chainstate::ConsensusHash;
 use clarity::types::chainstate::StacksAddress;
+use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::types::{BuffData, SequenceData};
 use clarity::vm::{ClarityName, ContractName, Value};
 use reqwest::header::CONTENT_LENGTH;
@@ -130,6 +131,13 @@ pub struct NodeInfo {
     pub stacks_tip_consensus_hash: ConsensusHash,
 }
 
+impl NodeInfo {
+    /// Create a new [`StacksBlockId`] from the node info.
+    pub fn chain_tip(&self) -> StacksBlockId {
+        StacksBlockId::new(&self.stacks_tip_consensus_hash, &self.stacks_tip)
+    }
+}
+
 /// Helper function for converting a hexadecimal string into an integer.
 fn parse_hex_u128(hex: &str) -> Result<u128, Error> {
     let hex_str = hex.trim_start_matches("0x");
@@ -221,9 +229,13 @@ impl StacksClient {
         fn_name: &ClarityName,
         sender: &StacksAddress,
         arguments: &[Value],
+        chain_tip: Option<&StacksBlockId>,
     ) -> Result<Value, Error> {
+        let tip = chain_tip
+            .map(|tip| tip.to_string())
+            .unwrap_or_else(|| "latest".to_string());
         let path = format!(
-            "/v2/contracts/call-read/{contract_principal}/{contract_name}/{fn_name}?tip=latest"
+            "/v2/contracts/call-read/{contract_principal}/{contract_name}/{fn_name}?tip={tip}"
         );
 
         let url = self

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -62,6 +62,9 @@ struct AccountEntryResponse {
 }
 
 /// Account info for a Stacks address.
+///
+/// The actual return type can be found here:
+/// https://github.com/stacks-network/stacks-core/blob/4.0.1/stackslib/src/net/api/getaccount.rs#L34-L46
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountInfo {
     /// The total balance of the account in micro-STX, including locked funds.
@@ -78,7 +81,7 @@ pub struct AccountInfo {
 ///
 /// The fields match the JSON fields returned from a Stacks node and are
 /// defined in:
-/// https://github.com/stacks-network/stacks-core/blob/2.5.0.0.5/docs/rpc-endpoints.md
+/// https://github.com/stacks-network/stacks-core/blob/4.0.1/docs/rpc-endpoints.md
 #[derive(Debug, Deserialize)]
 pub struct TxRejection {
     /// The error message. It should always be the string "transaction
@@ -119,7 +122,9 @@ pub enum SubmitTxResponse {
 /// Subset of the response from `GET /v2/info`.
 ///
 /// Despite the field name, `network_id` is the Stacks chain id used in
-/// transactions.
+/// transactions. This is a slimmed down version of the response containing
+/// only the fields we need, the full response can be seen in:
+/// https://github.com/stacks-network/stacks-core/blob/4.0.1/stackslib/src/net/api/getinfo.rs#L53-L85
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct NodeInfo {
     /// Stacks chain id reported by the node.

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -67,6 +67,7 @@ impl DepositAddressRegistry {
                 &ClarityName::from("get-next-address-id"),
                 &self.contract_principal,
                 &[],
+                None,
             )
             .await?;
 
@@ -112,6 +113,7 @@ impl DepositAddressRegistry {
                 &ClarityName::from("get-addresses"),
                 &self.contract_principal,
                 &arguments,
+                None,
             )
             .await?;
 

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -189,7 +189,8 @@ impl RewardClaimRegistry {
         let mut all = Vec::new();
         let mut cursor: Option<RegistrationKey> = None;
 
-        let chain_tip = Some(&self.client.get_node_info().await?.chain_tip());
+        let tip = self.client.get_node_info().await?.chain_tip();
+        let chain_tip = Some(&tip);
 
         loop {
             let page = self.get_pending_claims(cursor.as_ref(), chain_tip).await?;
@@ -305,6 +306,8 @@ impl TryFrom<ClarityValue> for PendingClaimsPage {
 #[cfg(test)]
 mod tests {
     use bitcoincore_rpc::jsonrpc::serde_json;
+    use clarity::types::chainstate::BlockHeaderHash;
+    use clarity::types::chainstate::ConsensusHash;
     use clarity::vm::types::OptionalData;
 
     use super::*;
@@ -501,7 +504,10 @@ mod tests {
             client,
         );
 
-        let result = registry.get_pending_claims(Some(&cursor), None).await.unwrap();
+        let result = registry
+            .get_pending_claims(Some(&cursor), None)
+            .await
+            .unwrap();
 
         assert_eq!(
             result,
@@ -573,11 +579,34 @@ mod tests {
             .serialize_to_hex()
             .unwrap();
 
+        let stacks_tip = "b5f9aa4423ffa7abb585fc00e2783c40225597ec112ee618db86ae23dbbbe88c";
+        let stacks_tip_consensus_hash = "dfe87cfd31c1a67fa8b989c83b79aa476e616758";
+        let tip = StacksBlockId::new(
+            &ConsensusHash::from_hex(stacks_tip_consensus_hash).unwrap(),
+            &BlockHeaderHash::from_hex(stacks_tip).unwrap(),
+        );
+
         let mut stacks_node_server = mockito::Server::new_async().await;
-        let path = "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest";
+        let info_mock = stacks_node_server
+            .mock("GET", "/v2/info")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{
+                    "network_id": 2147483648,
+                    "stacks_tip": "{stacks_tip}",
+                    "stacks_tip_consensus_hash": "{stacks_tip_consensus_hash}"
+                }}"#
+            ))
+            .expect(1)
+            .create();
+
+        let path = format!(
+            "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip={tip}"
+        );
 
         let empty_with_next = stacks_node_server
-            .mock("POST", path)
+            .mock("POST", path.as_str())
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [ClarityValue::none().serialize_to_hex().unwrap()]
             })))
@@ -591,7 +620,7 @@ mod tests {
             .create();
 
         let pending_then_done = stacks_node_server
-            .mock("POST", path)
+            .mock("POST", path.as_str())
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [skipped_hex]
             })))
@@ -620,6 +649,7 @@ mod tests {
         let result = registry.get_all_pending_claims().await.unwrap();
 
         assert_eq!(result, vec![pending]);
+        info_mock.assert();
         empty_with_next.assert();
         pending_then_done.assert();
     }

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use clarity::types::chainstate::StacksAddress;
+use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::ClarityName;
 use clarity::vm::ContractName;
 use clarity::vm::Value as ClarityValue;
@@ -140,6 +141,7 @@ impl RewardClaimRegistry {
     async fn get_pending_claims(
         &self,
         cursor: Option<&RegistrationKey>,
+        chain_tip: Option<&StacksBlockId>,
     ) -> Result<PendingClaimsPage, Error> {
         let cursor_arg = match cursor {
             Some(key) => {
@@ -169,6 +171,7 @@ impl RewardClaimRegistry {
                 &ClarityName::from("get-pending-claims"),
                 &self.deployer,
                 &[cursor_arg],
+                chain_tip,
             )
             .await?;
 
@@ -186,8 +189,10 @@ impl RewardClaimRegistry {
         let mut all = Vec::new();
         let mut cursor: Option<RegistrationKey> = None;
 
+        let chain_tip = Some(&self.client.get_node_info().await?.chain_tip());
+
         loop {
-            let page = self.get_pending_claims(cursor.as_ref()).await?;
+            let page = self.get_pending_claims(cursor.as_ref(), chain_tip).await?;
             all.extend(page.claims);
             match page.next {
                 Some(next) => cursor = Some(next),
@@ -428,7 +433,7 @@ mod tests {
             client,
         );
 
-        let result = registry.get_pending_claims(None).await.unwrap();
+        let result = registry.get_pending_claims(None, None).await.unwrap();
 
         assert_eq!(
             result,
@@ -496,7 +501,7 @@ mod tests {
             client,
         );
 
-        let result = registry.get_pending_claims(Some(&cursor)).await.unwrap();
+        let result = registry.get_pending_claims(Some(&cursor), None).await.unwrap();
 
         assert_eq!(
             result,
@@ -538,7 +543,7 @@ mod tests {
             client,
         );
 
-        let result = registry.get_pending_claims(None).await.unwrap();
+        let result = registry.get_pending_claims(None, None).await.unwrap();
 
         assert_eq!(result, PendingClaimsPage { claims: vec![], next: None });
         mock.assert();


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/46

## Changes

* The pagination of `get-pending-claims` now uses the same chain tip instead of the "latest" flag.

## Testing Information

Not much, yet. This new code is almost entirely unused.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
