### PR TITLE
fix: guard against re-entry

### DIFF
--- a/contracts/Clarinet.toml
+++ b/contracts/Clarinet.toml
@@ -72,3 +72,8 @@ epoch = 4.0
 path = "contracts/mock-signer-manager.clar"
 clarity_version = 6
 epoch = 4.0
+
+[contracts.malicious-signer-manager]
+path = "contracts/malicious-signer-manager.clar"
+clarity_version = 6
+epoch = 4.0

--- a/contracts/contracts/malicious-signer-manager.clar
+++ b/contracts/contracts/malicious-signer-manager.clar
@@ -1,0 +1,208 @@
+;; Test signer-manager that re-enters reward-claim-registry from trait
+;; callbacks. Trait-typed reentry uses mock-signer-manager (already
+;; published) so this contract does not reference itself. The registry
+;; guard is a single contract-wide flag, so the inner call still hits
+;; ERR_REENTRANT_CALL before dispatching on that trait.
+
+(impl-trait .reward-claim-traits.reward-claim-signer-manager-trait)
+(impl-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
+(use-trait signer-manager-trait 'ST000000000000000000002AMW42H.pox-5.signer-manager-trait)
+
+(define-constant REENTER_NONE u0)
+(define-constant REENTER_PROCESS_CLAIM u1)
+(define-constant REENTER_PROCESS_CLAIMS u2)
+(define-constant REENTER_CANCEL u3)
+(define-constant REENTER_SETTLE u4)
+(define-constant REENTER_ADD_CLAIMS u5)
+(define-constant REENTER_REGISTER u6)
+
+(define-data-var reenter-mode uint REENTER_NONE)
+(define-data-var reenter-staker principal tx-sender)
+(define-data-var last-reenter-error (optional uint) none)
+
+;; pox-5 callback: always accept the stake.
+;; #[allow(unnecessary_public)]
+(define-public (validate-stake!
+    ;; #[allow(unused_binding)]
+    (staker principal)
+    ;; #[allow(unused_binding)]
+    (first-index uint)
+    ;; #[allow(unused_binding)]
+    (num-indexes uint)
+    ;; #[allow(unused_binding)]
+    (amount-ustx uint)
+    ;; #[allow(unused_binding)]
+    (amount-sats uint)
+    ;; #[allow(unused_binding)]
+    (is-bond bool)
+    ;; #[allow(unused_binding)]
+    (signer-calldata (optional (buff 500)))
+  )
+  (ok true)
+)
+
+(define-public (register-self
+    (signer-manager <signer-manager-trait>)
+    (signer-key (buff 33))
+    (auth-id uint)
+    (signer-sig (buff 65))
+  )
+  (begin
+    (try! (contract-call? 'ST000000000000000000002AMW42H.pox-5 grant-signer-key
+      signer-key current-contract auth-id signer-sig
+    ))
+    (contract-call? 'ST000000000000000000002AMW42H.pox-5 register-signer
+      signer-manager signer-key
+    )
+  )
+)
+
+(define-private (note-reenter-err (err-code uint))
+  (var-set last-reenter-error (some err-code))
+)
+
+(define-private (attempt-reenter)
+  (if (is-eq (var-get reenter-mode) REENTER_NONE)
+    true
+    (begin
+      (var-set last-reenter-error none)
+      (if (is-eq (var-get reenter-mode) REENTER_PROCESS_CLAIM)
+        (match (contract-call? .reward-claim-registry process-reward-claim
+            (var-get reenter-staker)
+            .mock-signer-manager
+          )
+          ok-v (var-set last-reenter-error none)
+          err-v (note-reenter-err err-v)
+        )
+        (if (is-eq (var-get reenter-mode) REENTER_PROCESS_CLAIMS)
+          (match (contract-call? .reward-claim-registry process-reward-claims
+              .mock-signer-manager
+              (list (var-get reenter-staker))
+            )
+            ok-v (var-set last-reenter-error none)
+            err-v (note-reenter-err err-v)
+          )
+          (if (is-eq (var-get reenter-mode) REENTER_CANCEL)
+            (match (contract-call? .reward-claim-registry cancel-registration
+                (var-get reenter-staker)
+                current-contract
+              )
+              ok-v (var-set last-reenter-error none)
+              err-v (note-reenter-err err-v)
+            )
+            (if (is-eq (var-get reenter-mode) REENTER_SETTLE)
+              (match (contract-call? .reward-claim-registry settle-pending-withdrawal
+                  (var-get reenter-staker)
+                  .mock-signer-manager
+                  u1
+                )
+                ok-v (var-set last-reenter-error none)
+                err-v (note-reenter-err err-v)
+              )
+              (if (is-eq (var-get reenter-mode) REENTER_ADD_CLAIMS)
+                (match (contract-call? .reward-claim-registry add-claims
+                    (var-get reenter-staker)
+                    current-contract
+                    u100000
+                  )
+                  ok-v (var-set last-reenter-error none)
+                  err-v (note-reenter-err err-v)
+                )
+                (if (is-eq (var-get reenter-mode) REENTER_REGISTER)
+                  (match (contract-call? .reward-claim-registry register-for-claims
+                      (var-get reenter-staker)
+                      .mock-signer-manager
+                      u1
+                      true
+                      u100000
+                    )
+                    ok-v (var-set last-reenter-error none)
+                    err-v (note-reenter-err err-v)
+                  )
+                  true
+                )
+              )
+            )
+          )
+        )
+      )
+      true
+    )
+  )
+)
+
+;; #[allow(unnecessary_public)]
+(define-public (claim-staker-rewards
+    ;; #[allow(unused_binding)]
+    (staker principal)
+    ;; #[allow(unused_binding)]
+    (reward-cycle uint)
+    ;; #[allow(unused_binding)]
+    (bond-index (optional uint))
+  )
+  (begin
+    (attempt-reenter)
+    (ok {
+      earned: u0,
+      withdrawal-request: none,
+    })
+  )
+)
+
+;; #[allow(unnecessary_public)]
+(define-public (claim-rewards
+    ;; #[allow(unused_binding)]
+    (bond-periods (list 6 uint))
+    ;; #[allow(unused_binding)]
+    (reward-cycle uint)
+  )
+  (begin
+    (attempt-reenter)
+    (ok {
+      stx-rewards: { earned: u0, rewards-per-token: u0 },
+      bond-rewards: (list { earned: u0, bond-index: u0, rewards-per-token: u0 }),
+      bond-totals: u0,
+      total-rewards: u0,
+    })
+  )
+)
+
+;; #[allow(unnecessary_public)]
+(define-public (settle-accepted-withdrawal
+  ;; #[allow(unused_binding)]
+  (request-id uint)
+)
+  (begin
+    (attempt-reenter)
+    (ok true)
+  )
+)
+
+;; #[allow(unnecessary_public)]
+(define-public (reclaim-failed-withdrawal
+  ;; #[allow(unused_binding)]
+  (request-id uint)
+)
+  (begin
+    (attempt-reenter)
+    (ok true)
+  )
+)
+
+(define-public (set-reenter-mode
+    (mode uint)
+    (staker principal)
+  )
+  (begin
+    ;; #[allow(unchecked_data)]
+    (var-set reenter-mode mode)
+    ;; #[allow(unchecked_data)]
+    (var-set reenter-staker staker)
+    (var-set last-reenter-error none)
+    (ok true)
+  )
+)
+
+(define-read-only (get-last-reenter-error)
+  (var-get last-reenter-error)
+)

--- a/contracts/contracts/mock-signer-manager.clar
+++ b/contracts/contracts/mock-signer-manager.clar
@@ -16,6 +16,9 @@
 (define-data-var earned-amount uint u1000)
 (define-data-var withdrawal-id (optional uint) none)
 
+(define-data-var settle-should-err bool false)
+(define-data-var settle-err-code uint u1001)
+
 ;; pox-5 callback: always accept the stake so fixtures can register positions
 ;; under this mock without real signer-manager bookkeeping.
 ;; #[allow(unnecessary_public)]
@@ -97,7 +100,10 @@
   ;; #[allow(unused_binding)]
   (request-id uint)
 )
-  (ok true)
+  (if (var-get settle-should-err)
+    (err (var-get settle-err-code))
+    (ok true)
+  )
 )
 
 ;; #[allow(unnecessary_public)]
@@ -105,7 +111,10 @@
   ;; #[allow(unused_binding)]
   (request-id uint)
 )
-  (ok true)
+  (if (var-get settle-should-err)
+    (err (var-get settle-err-code))
+    (ok true)
+  )
 )
 
 ;; --- test setters ---
@@ -139,6 +148,20 @@
     (var-set claim-rewards-should-err should-error)
     ;; #[allow(unchecked_data)]
     (var-set claim-rewards-err-code code)
+    (ok true)
+  )
+)
+
+;; Configure settle-accepted-withdrawal / reclaim-failed-withdrawal:
+;; return (err code) when should-error, else (ok true).
+(define-public (set-settle-result
+    (should-error bool)
+    (code uint)
+  )
+  (begin
+    (var-set settle-should-err should-error)
+    ;; #[allow(unchecked_data)]
+    (var-set settle-err-code code)
     (ok true)
   )
 )

--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -19,5 +19,6 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
 - Only the staker may `cancel-registration` (admins cannot cancel for them). Remaining `prepaid-ustx` is refunded to the staker; pending L1 withdrawals remain settleable.
-- Pending L1 withdrawals are capped at 192 per registration; settlement is a separate permissionless step after sBTC accept/reject.
+- Pending L1 withdrawals are capped at `MAX_PENDING_WITHDRAWALS` 64 per registration; settlement is a separate permissionless step after sBTC accept/reject.
 - `get-pending-claims` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.
+- `get-pending-settlements` may return an empty `rows`, however, that does not mean the walk finished. Paginate with `next` until it is `next` is `none`.

--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -19,6 +19,5 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
 - Only the staker may `cancel-registration` (admins cannot cancel for them). Remaining `prepaid-ustx` is refunded to the staker; pending L1 withdrawals remain settleable.
-- Pending L1 withdrawals are capped at `MAX_PENDING_WITHDRAWALS` 64 per registration; settlement is a separate permissionless step after sBTC accept/reject.
+- Pending L1 withdrawals are capped at 192 per registration; settlement is a separate permissionless step after sBTC accept/reject.
 - `get-pending-claims` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.
-- `get-pending-settlements` may return an empty `rows`, however, that does not mean the walk finished. Paginate with `next` until it is `next` is `none`.

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -15,9 +15,7 @@
 (define-constant ERR_ZERO_FEE (err u604))
 ;; Nothing new to claim yet: next-claim-distribution has not fully elapsed
 (define-constant ERR_ALREADY_CLAIMED (err u605))
-;; This is thrown when there are more than 192 pending withdrawals for a
-;; registrant. This should not be reachable during PoX-5, which should not
-;; be around for more than 96 reward cycles.
+;; Thrown when a key would exceed 64 tracked request-ids.
 (define-constant ERR_TOO_MANY_PENDING (err u606))
 ;; The request-id is not a tracked pending withdrawal for this key
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
@@ -132,7 +130,7 @@
         staker: principal,
         signer-manager: principal,
     }
-    (list 192 uint)
+    (list 64 uint)
 )
 
 (define-map pending-withdrawal-ll
@@ -973,8 +971,9 @@
 )
 
 ;; Bookkeeping only. Appends `request-id` to key's pending-withdrawals entry
-;; (append + as-max-len? back to 192), erroring ERR_TOO_MANY_PENDING if full.
-;; Splices key into pending-withdrawal-ll if this is its first pending item.
+;; (append + as-max-len? back to u64), erroring
+;; ERR_TOO_MANY_PENDING if full. Splices key into pending-withdrawal-ll if
+;; this is its first pending item.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (append-pending-withdrawal
@@ -987,7 +986,9 @@
     (let (
             (current (default-to (list) (map-get? pending-withdrawals key)))
             (was-empty (is-eq current (list)))
-            (updated (unwrap! (as-max-len? (append current request-id) u192) ERR_TOO_MANY_PENDING))
+            (updated (unwrap! (as-max-len? (append current request-id) u64)
+                ERR_TOO_MANY_PENDING
+            ))
         )
         (map-set pending-withdrawals key updated)
         (if was-empty
@@ -1075,12 +1076,43 @@
     )
 )
 
-;; Fold step for get-pending-settlements. Reads the current node's pending
-;; request-ids, appends one row carrying the whole list, and advances `node`
-;; to the next entry. Every node in pending-withdrawal-ll has a nonempty
-;; pending-withdrawals entry (a node is spliced out when its list empties), so
-;; no filtering is needed and one row is emitted per node. Once `node` is none
-;; it is a no-op. `tick` is unused; it only bounds the iteration count.
+;; Fold step for filter-settleable-request-ids. Keeps `request-id` when
+;; sbtc-registry reports status `(some true)` or `(some false)` (signer
+;; accepted/rejected). Drops still-pending (`none`) and unknown ids.
+;;
+;; #[allow(unchecked_data)]
+(define-private (filter-settleable-step
+        (request-id uint)
+        (kept (list 64 uint))
+    )
+    (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
+            get-withdrawal-request request-id
+        )
+        request (match (get status request)
+            status-bool (default-to kept
+                (as-max-len? (append kept request-id) u64)
+            )
+            kept
+        )
+        kept
+    )
+)
+
+;; Filter a tracked request-id list down to settleable ids only.
+;;
+;; #[allow(unchecked_data)]
+(define-private (filter-settleable-request-ids
+        (request-ids (list 64 uint))
+    )
+    (fold filter-settleable-step request-ids (list))
+)
+
+;; Fold step for get-pending-settlements. From the current `node` it reads that
+;; pending-withdrawals entry, filters to settleable request-ids, appends a row
+;; when the filtered list is nonempty, records `last-visited`, and advances
+;; `node` to the next linked-list entry. Nodes with only still-pending
+;; (status none) ids still consume a tick without appending. Once `node` is
+;; none it is a no-op. `tick` is unused; it only bounds the iteration count.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (pending-settlements-step
@@ -1090,11 +1122,15 @@
                 staker: principal,
                 signer-manager: principal,
             }),
+            last-visited: (optional {
+                staker: principal,
+                signer-manager: principal,
+            }),
             rows: (list 100
                 {
                     staker: principal,
                     signer-manager: principal,
-                    request-ids: (list 192 uint),
+                    request-ids: (list 64 uint),
                 }
             ),
         })
@@ -1107,21 +1143,33 @@
             )))
             (match (map-get? pending-withdrawals key)
                 request-ids
-                (merge acc {
-                    node: next-node,
-                    rows: (default-to (get rows acc)
-                        (as-max-len?
-                            (append (get rows acc) {
-                                staker: (get staker key),
-                                signer-manager: (get signer-manager key),
-                                request-ids: request-ids,
-                            })
-                            u100
-                        )),
-                })
+                (let ((settleable (filter-settleable-request-ids request-ids)))
+                    (if (is-eq settleable (list))
+                        (merge acc {
+                            node: next-node,
+                            last-visited: (some key),
+                        })
+                        (merge acc {
+                            node: next-node,
+                            last-visited: (some key),
+                            rows: (default-to (get rows acc)
+                                (as-max-len?
+                                    (append (get rows acc) {
+                                        staker: (get staker key),
+                                        signer-manager: (get signer-manager key),
+                                        request-ids: settleable,
+                                    })
+                                    u100
+                                )),
+                        })
+                    )
+                )
                 ;; A linked-list node with no pending entry should never happen;
                 ;; skip it defensively rather than aborting the read.
-                (merge acc { node: next-node })
+                (merge acc {
+                    node: next-node,
+                    last-visited: (some key),
+                })
             )
         )
         ;; Past the tail: nothing left to visit.
@@ -1129,22 +1177,19 @@
     )
 )
 
-;; List keys with outstanding L1 withdrawal request-ids. Walks
-;; pending-withdrawal-ll from cursor, or from the head when cursor is none, and
-;; returns up to 100 rows. Every node has a nonempty pending-withdrawals entry,
-;; so each visited node yields exactly one row and a short page means the tail
-;; was reached. Rows are included whether or not their parent registration still
-;; exists. Does not check sbtc-registry status; the caller should check each
-;; request-id before paying gas to settle.
+;; List keys with settleable L1 withdrawal request-ids. Walks
+;; pending-withdrawal-ll from cursor, or from the head when cursor is none,
+;; and returns up to 100 rows whose request-ids have sbtc-registry status
+;; indicates the withdrawal has been accepted or rejected, omitting
+;; still-pending ids. A short or empty `rows` list does not mean the tail
+;; was reached, which happens only when the returned `next` cursor is none.
 ;;
-;; Parameters:
-;;   cursor  none to start at the head, or the last key from the previous page
-;;           so the walk resumes at that key's successor.
+;; Parameters: cursor  none to start at the head, or the `next` key from
+;;   the previous page so the walk resumes at that key's successor.
 ;;
-;; Returns:
-;;   ok wrapping a list of rows. Each row has staker, signer-manager, and
-;;   request-ids, every sbtc-registry request-id awaiting settlement for that
-;;   key, up to 192.
+;; Returns: ok wrapping { rows, next }. Each row has staker,
+;;   signer-manager, and settleable request-ids (up to 64). `next` is none
+;;   at the tail, or the last visited key when more nodes may remain.
 (define-read-only (get-pending-settlements (cursor (optional {
     staker: principal,
     signer-manager: principal,
@@ -1159,15 +1204,25 @@
                 )
                 (var-get pending-withdrawal-ll-head)
             ))
-        )
-        ;; PENDING_TICKS is the elided (list 100 uint) bounding the walk to at most
-        ;; 100 node visits per call.
-        (ok (get rows
-            (fold pending-settlements-step PENDING_TICKS {
+            ;; PENDING_TICKS is the elided (list 100 uint) bounding the walk to
+            ;; at most 100 node visits per call.
+            (walk (fold pending-settlements-step PENDING_TICKS {
                 node: start,
+                last-visited: none,
                 rows: (list),
-            })
-        ))
+            }))
+            ;; If `node` is still `some` after the fold, ticks ran out with more
+            ;; list ahead: resume after `last-visited`. If `node` is none, the
+            ;; walk reached the tail or the list was empty.
+            (next (match (get node walk)
+                more-to-do (get last-visited walk)
+                none
+            ))
+        )
+        (ok {
+            rows: (get rows walk),
+            next: next,
+        })
     )
 )
 
@@ -1178,12 +1233,16 @@
         (acc {
             target: uint,
             found: bool,
-            kept: (list 192 uint),
+            kept: (list 64 uint),
         })
     )
     (if (is-eq request-id (get target acc))
         (merge acc { found: true })
-        (merge acc { kept: (default-to (get kept acc) (as-max-len? (append (get kept acc) request-id) u192)) })
+        (merge acc {
+            kept: (default-to (get kept acc)
+                (as-max-len? (append (get kept acc) request-id) u64)
+            ),
+        })
     )
 )
 

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -15,7 +15,9 @@
 (define-constant ERR_ZERO_FEE (err u604))
 ;; Nothing new to claim yet: next-claim-distribution has not fully elapsed
 (define-constant ERR_ALREADY_CLAIMED (err u605))
-;; Thrown when a key would exceed 64 tracked request-ids.
+;; This is thrown when there are more than 192 pending withdrawals for a
+;; registrant. This should not be reachable during PoX-5, which should not
+;; be around for more than 96 reward cycles.
 (define-constant ERR_TOO_MANY_PENDING (err u606))
 ;; The request-id is not a tracked pending withdrawal for this key
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
@@ -141,7 +143,7 @@
         staker: principal,
         signer-manager: principal,
     }
-    (list 64 uint)
+    (list 192 uint)
 )
 
 (define-map pending-withdrawal-ll
@@ -1060,9 +1062,8 @@
 )
 
 ;; Bookkeeping only. Appends `request-id` to key's pending-withdrawals entry
-;; (append + as-max-len? back to u64), erroring
-;; ERR_TOO_MANY_PENDING if full. Splices key into pending-withdrawal-ll if
-;; this is its first pending item.
+;; (append + as-max-len? back to 192), erroring ERR_TOO_MANY_PENDING if full.
+;; Splices key into pending-withdrawal-ll if this is its first pending item.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (append-pending-withdrawal
@@ -1075,7 +1076,7 @@
     (let (
             (current (default-to (list) (map-get? pending-withdrawals key)))
             (was-empty (is-eq current (list)))
-            (updated (unwrap! (as-max-len? (append current request-id) u64) ERR_TOO_MANY_PENDING))
+            (updated (unwrap! (as-max-len? (append current request-id) u192) ERR_TOO_MANY_PENDING))
         )
         (map-set pending-withdrawals key updated)
         (if was-empty
@@ -1171,39 +1172,12 @@
     )
 )
 
-;; Fold step for filter-settleable-request-ids. Keeps `request-id` when
-;; sbtc-registry reports status `(some true)` or `(some false)` (signer
-;; accepted/rejected). Drops still-pending (`none`) and unknown ids.
-;;
-;; #[allow(unchecked_data)]
-(define-private (filter-settleable-step
-        (request-id uint)
-        (kept (list 64 uint))
-    )
-    (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry get-withdrawal-request
-        request-id
-    )
-        request (match (get status request)
-            status-bool (default-to kept (as-max-len? (append kept request-id) u64))
-            kept
-        )
-        kept
-    )
-)
-
-;; Filter a tracked request-id list down to settleable ids only.
-;;
-;; #[allow(unchecked_data)]
-(define-private (filter-settleable-request-ids (request-ids (list 64 uint)))
-    (fold filter-settleable-step request-ids (list))
-)
-
-;; Fold step for get-pending-settlements. From the current `node` it reads that
-;; pending-withdrawals entry, filters to settleable request-ids, appends a row
-;; when the filtered list is nonempty, records `last-visited`, and advances
-;; `node` to the next linked-list entry. Nodes with only still-pending
-;; (status none) ids still consume a tick without appending. Once `node` is
-;; none it is a no-op. `tick` is unused; it only bounds the iteration count.
+;; Fold step for get-pending-settlements. Reads the current node's pending
+;; request-ids, appends one row carrying the whole list, and advances `node`
+;; to the next entry. Every node in pending-withdrawal-ll has a nonempty
+;; pending-withdrawals entry (a node is spliced out when its list empties), so
+;; no filtering is needed and one row is emitted per node. Once `node` is none
+;; it is a no-op. `tick` is unused; it only bounds the iteration count.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (pending-settlements-step
@@ -1213,15 +1187,11 @@
                 staker: principal,
                 signer-manager: principal,
             }),
-            last-visited: (optional {
-                staker: principal,
-                signer-manager: principal,
-            }),
             rows: (list 100
                 {
                     staker: principal,
                     signer-manager: principal,
-                    request-ids: (list 64 uint),
+                    request-ids: (list 192 uint),
                 }
             ),
         })
@@ -1234,33 +1204,21 @@
             )))
             (match (map-get? pending-withdrawals key)
                 request-ids
-                (let ((settleable (filter-settleable-request-ids request-ids)))
-                    (if (is-eq settleable (list))
-                        (merge acc {
-                            node: next-node,
-                            last-visited: (some key),
-                        })
-                        (merge acc {
-                            node: next-node,
-                            last-visited: (some key),
-                            rows: (default-to (get rows acc)
-                                (as-max-len?
-                                    (append (get rows acc) {
-                                        staker: (get staker key),
-                                        signer-manager: (get signer-manager key),
-                                        request-ids: settleable,
-                                    })
-                                    u100
-                                )),
-                        })
-                    )
-                )
-                ;; A linked-list node with no pending entry should never happen;
-                ;; skip it defensively rather than aborting the read.
                 (merge acc {
                     node: next-node,
-                    last-visited: (some key),
+                    rows: (default-to (get rows acc)
+                        (as-max-len?
+                            (append (get rows acc) {
+                                staker: (get staker key),
+                                signer-manager: (get signer-manager key),
+                                request-ids: request-ids,
+                            })
+                            u100
+                        )),
                 })
+                ;; A linked-list node with no pending entry should never happen;
+                ;; skip it defensively rather than aborting the read.
+                (merge acc { node: next-node })
             )
         )
         ;; Past the tail: nothing left to visit.
@@ -1268,19 +1226,22 @@
     )
 )
 
-;; List keys with settleable L1 withdrawal request-ids. Walks
-;; pending-withdrawal-ll from cursor, or from the head when cursor is none,
-;; and returns up to 100 rows whose request-ids have sbtc-registry status
-;; indicates the withdrawal has been accepted or rejected, omitting
-;; still-pending ids. A short or empty `rows` list does not mean the tail
-;; was reached, which happens only when the returned `next` cursor is none.
+;; List keys with outstanding L1 withdrawal request-ids. Walks
+;; pending-withdrawal-ll from cursor, or from the head when cursor is none, and
+;; returns up to 100 rows. Every node has a nonempty pending-withdrawals entry,
+;; so each visited node yields exactly one row and a short page means the tail
+;; was reached. Rows are included whether or not their parent registration still
+;; exists. Does not check sbtc-registry status; the caller should check each
+;; request-id before paying gas to settle.
 ;;
-;; Parameters: cursor  none to start at the head, or the `next` key from
-;;   the previous page so the walk resumes at that key's successor.
+;; Parameters:
+;;   cursor  none to start at the head, or the last key from the previous page
+;;           so the walk resumes at that key's successor.
 ;;
-;; Returns: ok wrapping { rows, next }. Each row has staker,
-;;   signer-manager, and settleable request-ids (up to 64). `next` is none
-;;   at the tail, or the last visited key when more nodes may remain.
+;; Returns:
+;;   ok wrapping a list of rows. Each row has staker, signer-manager, and
+;;   request-ids, every sbtc-registry request-id awaiting settlement for that
+;;   key, up to 192.
 (define-read-only (get-pending-settlements (cursor (optional {
     staker: principal,
     signer-manager: principal,
@@ -1295,25 +1256,15 @@
                 )
                 (var-get pending-withdrawal-ll-head)
             ))
-            ;; PENDING_TICKS is the elided (list 100 uint) bounding the walk to
-            ;; at most 100 node visits per call.
-            (walk (fold pending-settlements-step PENDING_TICKS {
-                node: start,
-                last-visited: none,
-                rows: (list),
-            }))
-            ;; If `node` is still `some` after the fold, ticks ran out with more
-            ;; list ahead: resume after `last-visited`. If `node` is none, the
-            ;; walk reached the tail or the list was empty.
-            (next (match (get node walk)
-                more-to-do (get last-visited walk)
-                none
-            ))
         )
-        (ok {
-            rows: (get rows walk),
-            next: next,
-        })
+        ;; PENDING_TICKS is the elided (list 100 uint) bounding the walk to at most
+        ;; 100 node visits per call.
+        (ok (get rows
+            (fold pending-settlements-step PENDING_TICKS {
+                node: start,
+                rows: (list),
+            })
+        ))
     )
 )
 
@@ -1324,12 +1275,12 @@
         (acc {
             target: uint,
             found: bool,
-            kept: (list 64 uint),
+            kept: (list 192 uint),
         })
     )
     (if (is-eq request-id (get target acc))
         (merge acc { found: true })
-        (merge acc { kept: (default-to (get kept acc) (as-max-len? (append (get kept acc) request-id) u64)) })
+        (merge acc { kept: (default-to (get kept acc) (as-max-len? (append (get kept acc) request-id) u192)) })
     )
 )
 

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -986,9 +986,7 @@
     (let (
             (current (default-to (list) (map-get? pending-withdrawals key)))
             (was-empty (is-eq current (list)))
-            (updated (unwrap! (as-max-len? (append current request-id) u64)
-                ERR_TOO_MANY_PENDING
-            ))
+            (updated (unwrap! (as-max-len? (append current request-id) u64) ERR_TOO_MANY_PENDING))
         )
         (map-set pending-withdrawals key updated)
         (if was-empty
@@ -1085,13 +1083,11 @@
         (request-id uint)
         (kept (list 64 uint))
     )
-    (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
-            get-withdrawal-request request-id
-        )
+    (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry get-withdrawal-request
+        request-id
+    )
         request (match (get status request)
-            status-bool (default-to kept
-                (as-max-len? (append kept request-id) u64)
-            )
+            status-bool (default-to kept (as-max-len? (append kept request-id) u64))
             kept
         )
         kept
@@ -1101,9 +1097,7 @@
 ;; Filter a tracked request-id list down to settleable ids only.
 ;;
 ;; #[allow(unchecked_data)]
-(define-private (filter-settleable-request-ids
-        (request-ids (list 64 uint))
-    )
+(define-private (filter-settleable-request-ids (request-ids (list 64 uint)))
     (fold filter-settleable-step request-ids (list))
 )
 
@@ -1238,11 +1232,7 @@
     )
     (if (is-eq request-id (get target acc))
         (merge acc { found: true })
-        (merge acc {
-            kept: (default-to (get kept acc)
-                (as-max-len? (append (get kept acc) request-id) u64)
-            ),
-        })
+        (merge acc { kept: (default-to (get kept acc) (as-max-len? (append (get kept acc) request-id) u64)) })
     )
 )
 

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -28,6 +28,9 @@
 (define-constant ERR_ALREADY_REGISTERED (err u610))
 ;; Signer-manager associated with staker does not match inputs
 (define-constant ERR_SIGNER_MANAGER_MISMATCH (err u611))
+;; A reentrant call into this contract was detected while a signer-manager
+;; call was in flight (same pattern as pox-5's ERR_REENTRANT_CALL).
+(define-constant ERR_REENTRANT_CALL (err u612))
 
 ;; A (list 100 uint) whose only job is to bound the get-pending-claims /
 ;; get-pending-settlements folds to at most 100 node visits per call. The
@@ -55,6 +58,14 @@
 
 ;; This is the amount of uSTX escrowed per claim installment when buying
 (define-data-var fee-per-cycle uint u100000)
+
+;; Reentrancy guard: prevents cross-function re-entry through signer-manager
+;; trait calls (mirrors pox-5's signer-manager-call-active).
+(define-data-var signer-manager-call-active bool false)
+
+(define-private (validate-no-reentrancy)
+    (ok (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL))
+)
 
 (define-data-var registration-ll-head (optional {
     staker: principal,
@@ -550,21 +561,22 @@
 ;; Staker may act on their own registration; admins may register or top up
 ;; anyone. Cancel stays staker-only (see cancel-registration).
 (define-private (authorize-staker-or-admin (staker principal))
-    (ok (asserts! (or (is-eq tx-sender staker) (is-admin tx-sender)) ERR_UNAUTHORIZED))
+    (ok (asserts! (or (is-eq contract-caller staker) (is-admin contract-caller)) ERR_UNAUTHORIZED))
 )
 
-;; Escrow the STX fee for num-cycles installments unless tx-sender is an admin.
-;; Transfers into this contract. Returns the micro-STX amount escrowed.
+;; Escrow the STX fee for num-cycles installments unless contract-caller is
+;; an admin. Transfers into this contract. Returns the micro-STX amount
+;; escrowed.
 (define-private (escrow-registration-fee (num-cycles uint))
     (let (
             (price (var-get fee-per-cycle))
-            (amount (if (is-admin tx-sender)
+            (amount (if (is-admin contract-caller)
                 u0
                 (* num-cycles price)
             ))
         )
         (if (> amount u0)
-            (try! (stx-transfer? amount tx-sender current-contract))
+            (try! (stx-transfer? amount contract-caller current-contract))
             true
         )
         (ok amount)
@@ -581,7 +593,7 @@
 ;;
 ;; Parameters:
 ;;   staker                      The principal being registered. Must equal
-;;                               tx-sender unless the caller is an admin.
+;;                               contract-caller unless the caller is an admin.
 ;;   signer-manager              Together with staker forms the registration key.
 ;;                               Must be the signer pox-5 reports for the
 ;;                               position; every claim pulls from it.
@@ -593,8 +605,8 @@
 ;;                               false, up to two claims per reward cycle: step
 ;;                               of one, seeded on the first half, with catch-up
 ;;                               when a reward cycle is fully past.
-;;   fee                         STX paid by tx-sender. Buys the minimum of fee
-;;                               divided by fee-per-cycle and 192 installments.
+;;   fee                         STX paid by contract-caller. Buys the minimum of
+;;                               fee divided by fee-per-cycle and 192 installments.
 ;;                               Only the used portion is escrowed; any remainder
 ;;                               stays with the caller. Admins escrow nothing.
 ;;
@@ -640,7 +652,7 @@
             (print {
                 topic: "register-for-claims",
                 staker: staker,
-                registrant: tx-sender,
+                registrant: contract-caller,
                 signer-manager: signer,
                 start-reward-cycle: start-reward-cycle,
                 one-claim-per-reward-cycle: one-claim-per-reward-cycle,
@@ -658,10 +670,10 @@
 ;; later on advance.
 ;;
 ;; Parameters:
-;;   staker          The staker on the registration key. Must equal tx-sender
+;;   staker          The staker on the registration key. Must equal contract-caller
 ;;                   unless the caller is an admin.
 ;;   signer-manager  The signer-manager principal on the registration key.
-;;   fee             STX paid by tx-sender. Buys the minimum of fee divided by
+;;   fee             STX paid by contract-caller. Buys the minimum of fee divided by
 ;;                   fee-per-cycle and 192 installments. Only the used portion
 ;;                   is escrowed; any remainder stays with the caller. Admins
 ;;                   escrow nothing.
@@ -701,7 +713,7 @@
             (print {
                 topic: "add-claims",
                 staker: staker,
-                payer: tx-sender,
+                payer: contract-caller,
                 signer-manager: signer-manager,
                 num-cycles: num-cycles,
                 escrowed: escrowed,
@@ -718,12 +730,12 @@
 ;; key; those remain settleable via settle-pending-withdrawal.
 ;;
 ;; Parameters:
-;;   staker          The staker on the registration key. Must equal tx-sender.
+;;   staker          The staker on the registration key. Must equal contract-caller.
 ;;   signer-manager  The signer-manager principal on the registration key.
 ;;
 ;; Returns:
 ;;   ok with the micro-STX refunded to the staker, ERR_UNAUTHORIZED if
-;;   tx-sender is not the staker, or ERR_NOT_REGISTERED if no registration
+;;   contract-caller is not the staker, or ERR_NOT_REGISTERED if no registration
 ;;   exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
@@ -731,29 +743,33 @@
         (staker principal)
         (signer-manager principal)
     )
-    (let (
-            (key {
-                staker: staker,
-                signer-manager: signer-manager,
-            })
-            (registration (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
-            (refund (get prepaid-ustx registration))
-        )
-        (asserts! (is-eq tx-sender staker) ERR_UNAUTHORIZED)
-        (map-delete registrations key)
-        (ll-remove key)
-        (begin
-            (if (> refund u0)
-                (try! (as-contract? ((with-stx refund)) (try! (stx-transfer? refund tx-sender staker))))
-                true
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (let (
+                (key {
+                    staker: staker,
+                    signer-manager: signer-manager,
+                })
+                (registration (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
+                (refund (get prepaid-ustx registration))
             )
-            (print {
-                topic: "cancel-registration",
-                staker: staker,
-                signer-manager: signer-manager,
-                refund: refund,
-            })
-            (ok refund)
+            (asserts! (is-eq contract-caller staker) ERR_UNAUTHORIZED)
+            (map-delete registrations key)
+            (ll-remove key)
+            (begin
+                (if (> refund u0)
+                    (try! (as-contract? ((with-stx refund)) (try! (stx-transfer? refund tx-sender staker))))
+                    true
+                )
+                (print {
+                    topic: "cancel-registration",
+                    staker: staker,
+                    signer-manager: signer-manager,
+                    refund: refund,
+                })
+                (ok refund)
+            )
         )
     )
 )
@@ -818,6 +834,79 @@
     )
 )
 
+;; Wrap a signer-manager `claim-rewards` call with the reentrancy guard.
+;; This should be the only way claim-rewards is invoked from this contract.
+;;
+;; #[allow(unchecked_data)]
+(define-private (signer-manager-claim-rewards
+        (signer-manager <reward-claim-signer-manager-trait>)
+        (bond-periods (list 6 uint))
+        (reward-cycle uint)
+    )
+    (begin
+        (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL)
+        (var-set signer-manager-call-active true)
+        (let ((result (contract-call? signer-manager claim-rewards bond-periods reward-cycle)))
+            (var-set signer-manager-call-active false)
+            result
+        )
+    )
+)
+
+;; Wrap a signer-manager `claim-staker-rewards` call with the reentrancy guard.
+;; This should be the only way claim-staker-rewards is invoked from this contract.
+;;
+;; #[allow(unchecked_data)]
+(define-private (signer-manager-claim-staker-rewards
+        (signer-manager <reward-claim-signer-manager-trait>)
+        (staker principal)
+        (reward-cycle uint)
+        (bond-index (optional uint))
+    )
+    (begin
+        (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL)
+        (var-set signer-manager-call-active true)
+        (let ((result (contract-call? signer-manager claim-staker-rewards staker reward-cycle bond-index)))
+            (var-set signer-manager-call-active false)
+            result
+        )
+    )
+)
+
+;; Wrap a signer-manager `settle-accepted-withdrawal` call with the reentrancy
+;; guard. This should be the only way it is invoked from this contract.
+;;
+;; #[allow(unchecked_data)]
+(define-private (signer-manager-settle-accepted-withdrawal
+        (signer-manager <reward-claim-signer-manager-trait>)
+        (request-id uint)
+    )
+    (begin
+        (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL)
+        (var-set signer-manager-call-active true)
+        (try! (contract-call? signer-manager settle-accepted-withdrawal request-id))
+        (var-set signer-manager-call-active false)
+        (ok true)
+    )
+)
+
+;; Wrap a signer-manager `reclaim-failed-withdrawal` call with the reentrancy
+;; guard. This should be the only way it is invoked from this contract.
+;;
+;; #[allow(unchecked_data)]
+(define-private (signer-manager-reclaim-failed-withdrawal
+        (signer-manager <reward-claim-signer-manager-trait>)
+        (request-id uint)
+    )
+    (begin
+        (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL)
+        (var-set signer-manager-call-active true)
+        (try! (contract-call? signer-manager reclaim-failed-withdrawal request-id))
+        (var-set signer-manager-call-active false)
+        (ok true)
+    )
+)
+
 ;; Used by process-reward-claim-impl after a claim-rewards pull or when none
 ;; was needed. Always advances one installment whether claim-staker-rewards
 ;; pays or errors, so an untrusted signer-manager cannot stall the registration.
@@ -842,7 +931,7 @@
         (bond-index (optional uint))
         (current-distribution-cycle uint)
     )
-    (match (contract-call? signer-manager claim-staker-rewards staker reward-cycle bond-index)
+    (match (signer-manager-claim-staker-rewards signer-manager staker reward-cycle bond-index)
         claim-result
         ;; paid: advance and record any L1 withdrawal for later settlement
         (let ((withdrawal-request (get withdrawal-request claim-result)))
@@ -933,7 +1022,7 @@
                 )
                 u0
             )
-            (match (contract-call? signer-manager claim-rewards
+            (match (signer-manager-claim-rewards signer-manager
                 (match bond-index
                     idx (list idx)
                     (list)
@@ -1019,8 +1108,12 @@
         (staker principal)
         (signer-manager <reward-claim-signer-manager-trait>)
     )
-    (process-reward-claim-impl staker signer-manager
-        (contract-call? 'ST000000000000000000002AMW42H.pox-5 current-distribution-cycle)
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (process-reward-claim-impl staker signer-manager
+            (contract-call? 'ST000000000000000000002AMW42H.pox-5 current-distribution-cycle)
+        )
     )
 )
 
@@ -1044,13 +1137,17 @@
         (signer-manager <reward-claim-signer-manager-trait>)
         (stakers (list 100 principal))
     )
-    (ok (get claimed
-        (fold count-claim stakers {
-            signer-manager: signer-manager,
-            current-distribution-cycle: (contract-call? 'ST000000000000000000002AMW42H.pox-5 current-distribution-cycle),
-            claimed: u0,
-        })
-    ))
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (ok (get claimed
+            (fold count-claim stakers {
+                signer-manager: signer-manager,
+                current-distribution-cycle: (contract-call? 'ST000000000000000000002AMW42H.pox-5 current-distribution-cycle),
+                claimed: u0,
+            })
+        ))
+    )
 )
 
 ;; Fold step for process-reward-claims: match each process-reward-claim-impl result so a
@@ -1273,8 +1370,8 @@
         (match (get status request)
             accepted (begin
                 (if accepted
-                    (try! (contract-call? signer-manager settle-accepted-withdrawal request-id))
-                    (try! (contract-call? signer-manager reclaim-failed-withdrawal request-id))
+                    (try! (signer-manager-settle-accepted-withdrawal signer-manager request-id))
+                    (try! (signer-manager-reclaim-failed-withdrawal signer-manager request-id))
                 )
                 (if (is-eq (get kept fold-result) (list))
                     (begin
@@ -1320,7 +1417,11 @@
         (signer-manager <reward-claim-signer-manager-trait>)
         (request-id uint)
     )
-    (settle-pending-withdrawal-impl staker signer-manager request-id)
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (settle-pending-withdrawal-impl staker signer-manager request-id)
+    )
 )
 
 ;; Batch settle-pending-withdrawal for one signer-manager. The trait must be a
@@ -1340,12 +1441,16 @@
             request-id: uint,
         }))
     )
-    (ok (get resolved
-        (fold count-settlement items {
-            signer-manager: signer-manager,
-            resolved: u0,
-        })
-    ))
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (ok (get resolved
+            (fold count-settlement items {
+                signer-manager: signer-manager,
+                resolved: u0,
+            })
+        ))
+    )
 )
 
 ;; Fold step for settle-pending-withdrawals: match each

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -23,8 +23,8 @@
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
 ;; start-reward-cycle is before the position's first-reward-cycle
 (define-constant ERR_INVALID_START_REWARD_CYCLE (err u608))
-;; This is returned when the tx-sender is not allowed to register, add claims,
-;; or cancel for this staker.
+;; This is returned when the contract-caller is not allowed to register,
+;; add claims, or cancel for this staker.
 (define-constant ERR_UNAUTHORIZED (err u609))
 ;; A registration already exists for this staker and signer-manager
 (define-constant ERR_ALREADY_REGISTERED (err u610))
@@ -886,9 +886,10 @@
     (begin
         (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL)
         (var-set signer-manager-call-active true)
-        (try! (contract-call? signer-manager settle-accepted-withdrawal request-id))
-        (var-set signer-manager-call-active false)
-        (ok true)
+        (let ((result (contract-call? signer-manager settle-accepted-withdrawal request-id)))
+            (var-set signer-manager-call-active false)
+            result
+        )
     )
 )
 
@@ -903,9 +904,10 @@
     (begin
         (asserts! (not (var-get signer-manager-call-active)) ERR_REENTRANT_CALL)
         (var-set signer-manager-call-active true)
-        (try! (contract-call? signer-manager reclaim-failed-withdrawal request-id))
-        (var-set signer-manager-call-active false)
-        (ok true)
+        (let ((result (contract-call? signer-manager reclaim-failed-withdrawal request-id)))
+            (var-set signer-manager-call-active false)
+            result
+        )
     )
 )
 

--- a/contracts/deployments/default.simnet-plan.yaml
+++ b/contracts/deployments/default.simnet-plan.yaml
@@ -87,14 +87,19 @@ plan:
       path: contracts/mock-signer-manager.clar
       clarity-version: 6
     - transaction-type: emulated-contract-publish
-      contract-name: registry
-      emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-      path: contracts/registry.clar
-      clarity-version: 6
-    - transaction-type: emulated-contract-publish
       contract-name: reward-claim-registry
       emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
       path: contracts/reward-claim-registry.clar
+      clarity-version: 6
+    - transaction-type: emulated-contract-publish
+      contract-name: malicious-signer-manager
+      emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      path: contracts/malicious-signer-manager.clar
+      clarity-version: 6
+    - transaction-type: emulated-contract-publish
+      contract-name: registry
+      emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      path: contracts/registry.clar
       clarity-version: 6
     - transaction-type: emulated-contract-publish
       contract-name: signer-manager

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -31,6 +31,7 @@ export const wallet4 = accounts.get("wallet_4")!;
 
 export const SIGNER_MANAGER = `${deployer}.signer-manager`;
 export const MOCK_SIGNER_MANAGER = `${deployer}.mock-signer-manager`;
+export const MALICIOUS_SIGNER_MANAGER = `${deployer}.malicious-signer-manager`;
 export const SWEEP_REGISTRY = `${deployer}.reward-claim-registry`;
 export const SBTC_TOKEN =
   "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
@@ -60,6 +61,16 @@ const CHAIN_ID = 2147483648;
 export const SIGNER_PRIVATE_KEY = "a".repeat(63) + "1";
 /** Distinct key for mock-signer-manager so both can be registered in one simnet. */
 export const MOCK_SIGNER_PRIVATE_KEY = "b".repeat(63) + "1";
+/** Distinct key for malicious-signer-manager reentrancy tests. */
+export const MALICIOUS_SIGNER_PRIVATE_KEY = "c".repeat(63) + "1";
+
+/** Reentry modes for malicious-signer-manager.set-reenter-mode. */
+export const REENTER_NONE = 0n;
+export const REENTER_PROCESS_CLAIMS = 2n;
+export const REENTER_CANCEL = 3n;
+export const REENTER_SETTLE = 4n;
+export const REENTER_ADD_CLAIMS = 5n;
+export const REENTER_REGISTER = 6n;
 
 // reward-claim-registry error codes
 export const ERR_NOT_REGISTERED = 600n;
@@ -306,6 +317,59 @@ export function setMockClaimRewardsResult(shouldError: boolean, code = 1001n) {
     [Cl.bool(shouldError), Cl.uint(code)],
     deployer,
   );
+}
+
+export function registerMaliciousSignerManager(
+  privateKey = MALICIOUS_SIGNER_PRIVATE_KEY,
+) {
+  const authId = authIdCounter++;
+  const signerKey = compressPublicKey(privateKeyToPublic(privateKey));
+  const signerSig = signSignerKeyGrant(MALICIOUS_SIGNER_MANAGER, authId, privateKey);
+  return simnet.callPublicFn(
+    "malicious-signer-manager",
+    "register-self",
+    [
+      Cl.principal(MALICIOUS_SIGNER_MANAGER),
+      Cl.bufferFromHex(signerKey),
+      Cl.uint(authId),
+      Cl.bufferFromHex(signerSig),
+    ],
+    deployer,
+  );
+}
+
+/** Stake `amount` uSTX under malicious-signer-manager. */
+export function stakeForMalicious(staker: string, amount: bigint, numCycles: bigint) {
+  return simnet.callPublicFn(
+    POX5,
+    "stake",
+    [
+      Cl.principal(MALICIOUS_SIGNER_MANAGER),
+      Cl.uint(amount),
+      Cl.uint(numCycles),
+      Cl.uint(burnHeight()),
+      Cl.none(),
+    ],
+    staker,
+  );
+}
+
+export function setMaliciousReenterMode(mode: bigint, staker: string) {
+  return simnet.callPublicFn(
+    "malicious-signer-manager",
+    "set-reenter-mode",
+    [Cl.uint(mode), Cl.principal(staker)],
+    deployer,
+  );
+}
+
+export function getMaliciousLastReenterError() {
+  return simnet.callReadOnlyFn(
+    "malicious-signer-manager",
+    "get-last-reenter-error",
+    [],
+    deployer,
+  ).result;
 }
 
 export function setMockClaimStakerResult(

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -372,6 +372,15 @@ export function getMaliciousLastReenterError() {
   ).result;
 }
 
+export function setMockSettleResult(shouldError: boolean, code = 1001n) {
+  return simnet.callPublicFn(
+    "mock-signer-manager",
+    "set-settle-result",
+    [Cl.bool(shouldError), Cl.uint(code)],
+    deployer,
+  );
+}
+
 export function setMockClaimStakerResult(
   shouldError: boolean,
   code = 1001n,

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -575,7 +575,7 @@ export function getPendingClaims(cursor: OptionalCV = Cl.none()) {
   ).result;
 }
 
-export function getPendingSettlements(cursor = Cl.none()) {
+export function getPendingSettlements(cursor: OptionalCV = Cl.none()) {
   return simnet.callReadOnlyFn(
     "reward-claim-registry",
     "get-pending-settlements",

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -640,7 +640,7 @@ export function getPendingClaims(cursor: OptionalCV = Cl.none()) {
   ).result;
 }
 
-export function getPendingSettlements(cursor: OptionalCV = Cl.none()) {
+export function getPendingSettlements(cursor = Cl.none()) {
   return simnet.callReadOnlyFn(
     "reward-claim-registry",
     "get-pending-settlements",

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -74,6 +74,7 @@ export const ERR_INVALID_START_REWARD_CYCLE = 608n;
 export const ERR_UNAUTHORIZED = 609n;
 export const ERR_ALREADY_REGISTERED = 610n;
 export const ERR_SIGNER_MANAGER_MISMATCH = 611n;
+export const ERR_REENTRANT_CALL = 612n;
 
 /** reward-claim-registry's default fee-per-sweep. */
 export const FEE_PER_CLAIM = 100_000n;

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -10,9 +10,16 @@ import {
   ERR_NOT_REGISTERED,
   ERR_SIGNER_MANAGER_MISMATCH,
   ERR_UNKNOWN_PENDING_WITHDRAWAL,
+  ERR_REENTRANT_CALL,
   ERR_UNAUTHORIZED,
   ERR_ZERO_FEE,
   FEE_PER_CLAIM,
+  MALICIOUS_SIGNER_MANAGER,
+  REENTER_ADD_CLAIMS,
+  REENTER_CANCEL,
+  REENTER_PROCESS_CLAIMS,
+  REENTER_REGISTER,
+  REENTER_SETTLE,
   addClaims,
   MOCK_SIGNER_MANAGER,
   SIGNER_MANAGER,
@@ -28,9 +35,11 @@ import {
   getPendingSettlements,
   getPendingClaims,
   getEarned,
+  getMaliciousLastReenterError,
   getRegistration,
   initialNextClaimDistribution,
   initPox5,
+  registerMaliciousSignerManager,
   mineUntilPastDistribution,
   processRewardClaim,
   registerForBond,
@@ -39,10 +48,12 @@ import {
   registerSignerManager,
   rejectWithdrawal,
   sbtcBalance,
+  setMaliciousReenterMode,
   setMockClaimRewardsResult,
   setMockClaimStakerResult,
   setupBond,
   stakeFor,
+  stakeForMalicious,
   stakeForMock,
   stakeWithPoxAddr,
   stxBalance,
@@ -1384,5 +1395,90 @@ describe("claim schedule invariants", () => {
         stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
       );
     });
+  });
+});
+
+// Clarity rejects calling the same public function already on the stack
+// (CircularReference). The guard is for *cross-function* reentry: a signer-manager
+// callback invoking process-reward-claims (private impl), cancel, or settle.
+describe("reentrancy", () => {
+  beforeEach(() => {
+    initPox5();
+    registerMaliciousSignerManager();
+    stakeForMalicious(wallet1, SIGNER_SET_MIN_USTX, 4n);
+    registerForClaims(
+      wallet1,
+      3n * FEE_PER_CLAIM,
+      wallet1,
+      MALICIOUS_SIGNER_MANAGER,
+      STX_START,
+      true,
+    );
+    mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+  });
+
+  function expectSingleAdvance() {
+    expect(getRegistration(wallet1, MALICIOUS_SIGNER_MANAGER)).toBeSome(
+      stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
+    );
+  }
+
+  it("blocks process-reward-claims reentry from claim-staker-rewards", () => {
+    setMaliciousReenterMode(REENTER_PROCESS_CLAIMS, wallet1);
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.none(),
+    );
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
+    expectSingleAdvance();
+  });
+
+  it("blocks cancel-registration reentry from claim-staker-rewards", () => {
+    const before = stxBalance(wallet1);
+    setMaliciousReenterMode(REENTER_CANCEL, wallet1);
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.none(),
+    );
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
+    expectSingleAdvance();
+    expect(stxBalance(wallet1)).toBe(before);
+  });
+
+  it("blocks settle-pending-withdrawal reentry from claim-staker-rewards", () => {
+    setMaliciousReenterMode(REENTER_SETTLE, wallet1);
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.none(),
+    );
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
+    expectSingleAdvance();
+  });
+
+  it("blocks process-reward-claims reentry from claim-rewards (pull path)", () => {
+    fundAndCalculateRewards(2000n, 1n);
+    expect(getEarned(MALICIOUS_SIGNER_MANAGER, 1n, Cl.none())).toBeGreaterThan(0n);
+
+    setMaliciousReenterMode(REENTER_PROCESS_CLAIMS, wallet1);
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.none(),
+    );
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
+    expectSingleAdvance();
+  });
+
+  it("rejects add-claims reentry via authorize-staker-or-admin, not the reentrancy gate", () => {
+    setMaliciousReenterMode(REENTER_ADD_CLAIMS, wallet1);
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.none(),
+    );
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_UNAUTHORIZED));
+    expectSingleAdvance();
+  });
+
+  it("rejects register-for-claims reentry via authorize-staker-or-admin, not the reentrancy gate", () => {
+    setMaliciousReenterMode(REENTER_REGISTER, wallet1);
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.none(),
+    );
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_UNAUTHORIZED));
+    expectSingleAdvance();
   });
 });

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -133,6 +133,17 @@ function settlement(staker: string, requestIds: bigint[]) {
   });
 }
 
+/** Expected `ok` payload from `get-pending-settlements`: `{ rows, next }`. */
+function pendingSettlementsPage(
+  rows: ReturnType<typeof settlement>[],
+  next: ClarityValue = Cl.none(),
+) {
+  return Cl.tuple({
+    rows: Cl.list(rows),
+    next,
+  });
+}
+
 /** Register an STX-stake position and mine until its first claim is pending. */
 function registerStxAndAdvance(staker: string, fee: bigint, sender = staker) {
   const result = registerForClaims(staker, fee, sender, SIGNER_MANAGER, STX_START, true);
@@ -487,7 +498,8 @@ describe("cancel-registration", () => {
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
 
     expect(processRewardClaim(wallet2, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet2, [1n])]));
+    // Still pending in sbtc-registry (status none): not settleable yet.
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
 
     expect(
       simnet.callPublicFn(
@@ -498,9 +510,10 @@ describe("cancel-registration", () => {
       ).result,
     ).toBeOk(Cl.uint(2n * FEE_PER_CLAIM));
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet2, [1n])]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
 
     acceptWithdrawal(1n, 30n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet2, [1n])]));
     expect(
       simnet.callPublicFn(
         "reward-claim-registry",
@@ -509,7 +522,7 @@ describe("cancel-registration", () => {
         wallet3,
       ).result,
     ).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 });
 
@@ -993,32 +1006,46 @@ describe("L1 withdrawal path + settlements", () => {
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
   });
 
-  it("records a withdrawal request-id and lists it as a pending settlement", () => {
+  it("tracks a withdrawal, which is pending if accepted in the sbtc-registry", () => {
     const { result } = processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet1, [1n])]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+
+    acceptWithdrawal(1n, 30n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
+  });
+
+  it("tracks a withdrawal, which is pending if rejected in the sbtc-registry", () => {
+    const { result } = processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
+    expect(result).toBeOk(Cl.some(Cl.uint(1)));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+
+    rejectWithdrawal(1n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
   });
 
   it("settles an ACCEPTED withdrawal and clears it from the settlement list", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     acceptWithdrawal(1n, 30n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("settles a REJECTED withdrawal (reclaims to the staker) and clears it", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     rejectWithdrawal(1n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("is a no-op while the withdrawal is still pending", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeOk(Cl.bool(false));
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet1, [1n])]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("errors on an unknown pending withdrawal", () => {
@@ -1031,6 +1058,7 @@ describe("L1 withdrawal path + settlements", () => {
   it("batch settle-pending-withdrawals resolves accepted items and counts them", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     acceptWithdrawal(1n, 30n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
     const { result } = simnet.callPublicFn(
       "reward-claim-registry",
       "settle-pending-withdrawals",
@@ -1044,8 +1072,147 @@ describe("L1 withdrawal path + settlements", () => {
       wallet2,
     );
     expect(result).toBeOk(Cl.uint(1));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
+});
+
+describe("get-pending-settlements pagination", () => {
+  it(
+    "paginates past not-yet-settleable withdrawals across >100 stakers (Rust get_all style)",
+    () => {
+      // 150 stakers on pending-withdrawal-ll; 70 of them get a second claim so
+      // there are 220 withdrawal IDs total. 5 not-settleable (status none) in
+      // [0,100) and 5 in [100,150). PENDING_TICKS=100, so two pages of rows:
+      // 95 + 45 settleable staker rows.
+      const TOTAL_STAKERS = 150;
+      const DUAL_CLAIM_COUNT = 70; // 150 + 70 = 220 withdrawal IDs
+      const notSettleable = new Set([10, 30, 50, 70, 90, 110, 130, 140, 145, 149]);
+
+      initPox5();
+      registerSignerManager(SIGNER_PRIVATE_KEY);
+
+      const stakers = Array.from({ length: TOTAL_STAKERS }, (_, i) => {
+        const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+        return privateKeyToAddress(hex, "testnet");
+      });
+
+      for (let i = 0; i < TOTAL_STAKERS; i++) {
+        const staker = stakers[i]!;
+        expect(
+          simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+        ).toBeOk(Cl.bool(true));
+        stakeWithPoxAddr(staker, SIGNER_SET_MIN_USTX, 6n, 100n);
+        expect(
+          registerForClaims(
+            staker,
+            3n * FEE_PER_CLAIM,
+            deployer,
+            SIGNER_MANAGER,
+            STX_START,
+            true,
+          ).result,
+        ).toBeOk(Cl.uint(3));
+      }
+
+      fundAndClaimSignerRewards(500_000n, 1n);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+
+      const idsByStaker = new Map<string, bigint[]>();
+      const readWithdrawalId = (result: ClarityValue): bigint => {
+        const json = cvToJSON(result) as {
+          success: boolean;
+          value: { value: { value: string } };
+        };
+        expect(json.success).toBe(true);
+        return BigInt(json.value.value.value);
+      };
+
+      for (const staker of stakers) {
+        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
+        idsByStaker.set(staker, [readWithdrawalId(result)]);
+      }
+
+      fundAndClaimSignerRewards(500_000n, 2n);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST + 2n);
+
+      for (let i = 0; i < DUAL_CLAIM_COUNT; i++) {
+        const staker = stakers[i]!;
+        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
+        idsByStaker.get(staker)!.push(readWithdrawalId(result));
+      }
+
+      const allIds = [...idsByStaker.values()].flat();
+      expect(allIds).toHaveLength(220);
+      expect(new Set(allIds).size).toBe(220);
+
+      // Make every id settleable except those belonging to notSettleable stakers.
+      for (let i = 0; i < TOTAL_STAKERS; i++) {
+        if (notSettleable.has(i)) continue;
+        for (const id of idsByStaker.get(stakers[i]!)!) {
+          expect(rejectWithdrawal(id).result).toBeOk(Cl.bool(true));
+        }
+      }
+
+      const expectedStakers = stakers.filter((_, i) => !notSettleable.has(i));
+      expect(expectedStakers).toHaveLength(140);
+      const notSettleableStakers = new Set(
+        [...notSettleable].map((i) => stakers[i]!),
+      );
+
+      const allRows: Array<{ staker: string; requestIds: string[] }> = [];
+      let cursor: OptionalCV = Cl.none();
+      const pageSizes: number[] = [];
+      for (let guard = 0; guard < 10; guard++) {
+        const json = cvToJSON(getPendingSettlements(cursor));
+        expect(json.success).toBe(true);
+        const page = json.value.value as {
+          rows: {
+            value: Array<{
+              value: {
+                staker: { value: string };
+                "request-ids": { value: Array<{ value: string }> };
+              };
+            }>;
+          };
+          next: {
+            value: null | {
+              value: { staker: { value: string }; "signer-manager": { value: string } };
+            };
+          };
+        };
+
+        pageSizes.push(page.rows.value.length);
+        for (const row of page.rows.value) {
+          const staker = row.value.staker.value;
+          expect(notSettleableStakers.has(staker)).toBe(false);
+          const requestIds = row.value["request-ids"].value.map((id) => id.value);
+          expect(requestIds.length).toBeGreaterThan(0);
+          allRows.push({ staker, requestIds });
+        }
+
+        if (page.next.value === null) {
+          break;
+        }
+        const nextKey = page.next.value.value;
+        cursor = Cl.some(
+          Cl.tuple({
+            staker: Cl.principal(nextKey.staker.value),
+            "signer-manager": Cl.principal(nextKey["signer-manager"].value),
+          }),
+        );
+      }
+
+      expect(pageSizes).toEqual([95, 45]);
+      expect(allRows.map((row) => row.staker)).toEqual(expectedStakers);
+
+      const listedIds = allRows.flatMap((row) => row.requestIds.map((id) => BigInt(id)));
+      const expectedIds = expectedStakers.flatMap((staker) => idsByStaker.get(staker)!);
+      expect(listedIds.sort((a, b) => (a < b ? -1 : 1))).toEqual(
+        [...expectedIds].sort((a, b) => (a < b ? -1 : 1)),
+      );
+    },
+    300_000,
+  );
 });
 
 // Schedule / advance invariants. Several STX boundary cases are already

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -51,6 +51,7 @@ import {
   setMaliciousReenterMode,
   setMockClaimRewardsResult,
   setMockClaimStakerResult,
+  setMockSettleResult,
   setupBond,
   stakeFor,
   stakeForMalicious,
@@ -1313,5 +1314,69 @@ describe("reentrancy", () => {
     );
     expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_UNAUTHORIZED));
     expectSingleAdvance();
+  });
+});
+
+describe("batch settle SM error does not stick the reentrancy lock", () => {
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    registerMockSignerManager();
+    stakeWithPoxAddr(wallet2, SIGNER_SET_MIN_USTX, 2n, 100n);
+    stakeForMock(wallet3, SIGNER_SET_MIN_USTX, 4n);
+    registerForClaims(wallet2, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet3, 3n * FEE_PER_CLAIM, wallet3, MOCK_SIGNER_MANAGER, STX_START, true);
+    fundAndClaimSignerRewards(2000n, 1n);
+    mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+  });
+
+  it("batch settle-pending-withdrawals still allows later gated calls after the SM errors", () => {
+    // Real L1 withdrawal so sbtc-registry has request-id 1 with an accepted status.
+    expect(processRewardClaim(wallet2, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
+    acceptWithdrawal(1n, 30n);
+
+    // Mock SM tracks that same request-id so settle dispatches to the mock.
+    setMockClaimStakerResult(false, 1001n, 1000n, Cl.some(Cl.uint(1)));
+    expect(processRewardClaim(wallet3, wallet3, MOCK_SIGNER_MANAGER).result).toBeOk(
+      Cl.some(Cl.uint(1)),
+    );
+
+    setMockSettleResult(true, 4242n);
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "settle-pending-withdrawals",
+        [
+          Cl.principal(MOCK_SIGNER_MANAGER),
+          Cl.list([
+            Cl.tuple({ staker: Cl.principal(wallet3), "request-id": Cl.uint(1) }),
+          ]),
+        ],
+        wallet2,
+      ).result,
+    ).toBeOk(Cl.uint(0));
+
+    // Lock was cleared: the SM error surfaces, not ERR_REENTRANT_CALL.
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "settle-pending-withdrawal",
+        [Cl.principal(wallet3), Cl.principal(MOCK_SIGNER_MANAGER), Cl.uint(1)],
+        wallet2,
+      ).result,
+    ).toBeErr(Cl.uint(4242));
+    expect(processRewardClaim(wallet3, wallet3, MOCK_SIGNER_MANAGER).result).toBeErr(
+      Cl.uint(ERR_ALREADY_CLAIMED),
+    );
+
+    setMockSettleResult(false);
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "settle-pending-withdrawal",
+        [Cl.principal(wallet3), Cl.principal(MOCK_SIGNER_MANAGER), Cl.uint(1)],
+        wallet2,
+      ).result,
+    ).toBeOk(Cl.bool(true));
   });
 });

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -144,17 +144,6 @@ function settlement(staker: string, requestIds: bigint[]) {
   });
 }
 
-/** Expected `ok` payload from `get-pending-settlements`: `{ rows, next }`. */
-function pendingSettlementsPage(
-  rows: ReturnType<typeof settlement>[],
-  next: ClarityValue = Cl.none(),
-) {
-  return Cl.tuple({
-    rows: Cl.list(rows),
-    next,
-  });
-}
-
 /** Register an STX-stake position and mine until its first claim is pending. */
 function registerStxAndAdvance(staker: string, fee: bigint, sender = staker) {
   const result = registerForClaims(staker, fee, sender, SIGNER_MANAGER, STX_START, true);
@@ -509,8 +498,7 @@ describe("cancel-registration", () => {
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
 
     expect(processRewardClaim(wallet2, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
-    // Still pending in sbtc-registry (status none): not settleable yet.
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet2, [1n])]));
 
     expect(
       simnet.callPublicFn(
@@ -521,10 +509,9 @@ describe("cancel-registration", () => {
       ).result,
     ).toBeOk(Cl.uint(2n * FEE_PER_CLAIM));
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet2, [1n])]));
 
     acceptWithdrawal(1n, 30n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet2, [1n])]));
     expect(
       simnet.callPublicFn(
         "reward-claim-registry",
@@ -533,7 +520,7 @@ describe("cancel-registration", () => {
         wallet3,
       ).result,
     ).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([]));
   });
 });
 
@@ -1017,46 +1004,32 @@ describe("L1 withdrawal path + settlements", () => {
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
   });
 
-  it("tracks a withdrawal, which is pending if accepted in the sbtc-registry", () => {
+  it("records a withdrawal request-id and lists it as a pending settlement", () => {
     const { result } = processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
-
-    acceptWithdrawal(1n, 30n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
-  });
-
-  it("tracks a withdrawal, which is pending if rejected in the sbtc-registry", () => {
-    const { result } = processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
-    expect(result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
-
-    rejectWithdrawal(1n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet1, [1n])]));
   });
 
   it("settles an ACCEPTED withdrawal and clears it from the settlement list", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     acceptWithdrawal(1n, 30n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([]));
   });
 
   it("settles a REJECTED withdrawal (reclaims to the staker) and clears it", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     rejectWithdrawal(1n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([]));
   });
 
   it("is a no-op while the withdrawal is still pending", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeOk(Cl.bool(false));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet1, [1n])]));
   });
 
   it("errors on an unknown pending withdrawal", () => {
@@ -1069,7 +1042,6 @@ describe("L1 withdrawal path + settlements", () => {
   it("batch settle-pending-withdrawals resolves accepted items and counts them", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     acceptWithdrawal(1n, 30n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([settlement(wallet1, [1n])]));
     const { result } = simnet.callPublicFn(
       "reward-claim-registry",
       "settle-pending-withdrawals",
@@ -1083,147 +1055,8 @@ describe("L1 withdrawal path + settlements", () => {
       wallet2,
     );
     expect(result).toBeOk(Cl.uint(1));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingSettlements()).toBeOk(Cl.list([]));
   });
-});
-
-describe("get-pending-settlements pagination", () => {
-  it(
-    "paginates past not-yet-settleable withdrawals across >100 stakers (Rust get_all style)",
-    () => {
-      // 150 stakers on pending-withdrawal-ll; 70 of them get a second claim so
-      // there are 220 withdrawal IDs total. 5 not-settleable (status none) in
-      // [0,100) and 5 in [100,150). PENDING_TICKS=100, so two pages of rows:
-      // 95 + 45 settleable staker rows.
-      const TOTAL_STAKERS = 150;
-      const DUAL_CLAIM_COUNT = 70; // 150 + 70 = 220 withdrawal IDs
-      const notSettleable = new Set([10, 30, 50, 70, 90, 110, 130, 140, 145, 149]);
-
-      initPox5();
-      registerSignerManager(SIGNER_PRIVATE_KEY);
-
-      const stakers = Array.from({ length: TOTAL_STAKERS }, (_, i) => {
-        const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
-        return privateKeyToAddress(hex, "testnet");
-      });
-
-      for (let i = 0; i < TOTAL_STAKERS; i++) {
-        const staker = stakers[i]!;
-        expect(
-          simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
-        ).toBeOk(Cl.bool(true));
-        stakeWithPoxAddr(staker, SIGNER_SET_MIN_USTX, 6n, 100n);
-        expect(
-          registerForClaims(
-            staker,
-            3n * FEE_PER_CLAIM,
-            deployer,
-            SIGNER_MANAGER,
-            STX_START,
-            true,
-          ).result,
-        ).toBeOk(Cl.uint(3));
-      }
-
-      fundAndClaimSignerRewards(500_000n, 1n);
-      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
-
-      const idsByStaker = new Map<string, bigint[]>();
-      const readWithdrawalId = (result: ClarityValue): bigint => {
-        const json = cvToJSON(result) as {
-          success: boolean;
-          value: { value: { value: string } };
-        };
-        expect(json.success).toBe(true);
-        return BigInt(json.value.value.value);
-      };
-
-      for (const staker of stakers) {
-        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
-        idsByStaker.set(staker, [readWithdrawalId(result)]);
-      }
-
-      fundAndClaimSignerRewards(500_000n, 2n);
-      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST + 2n);
-
-      for (let i = 0; i < DUAL_CLAIM_COUNT; i++) {
-        const staker = stakers[i]!;
-        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
-        idsByStaker.get(staker)!.push(readWithdrawalId(result));
-      }
-
-      const allIds = [...idsByStaker.values()].flat();
-      expect(allIds).toHaveLength(220);
-      expect(new Set(allIds).size).toBe(220);
-
-      // Make every id settleable except those belonging to notSettleable stakers.
-      for (let i = 0; i < TOTAL_STAKERS; i++) {
-        if (notSettleable.has(i)) continue;
-        for (const id of idsByStaker.get(stakers[i]!)!) {
-          expect(rejectWithdrawal(id).result).toBeOk(Cl.bool(true));
-        }
-      }
-
-      const expectedStakers = stakers.filter((_, i) => !notSettleable.has(i));
-      expect(expectedStakers).toHaveLength(140);
-      const notSettleableStakers = new Set(
-        [...notSettleable].map((i) => stakers[i]!),
-      );
-
-      const allRows: Array<{ staker: string; requestIds: string[] }> = [];
-      let cursor: OptionalCV = Cl.none();
-      const pageSizes: number[] = [];
-      for (let guard = 0; guard < 10; guard++) {
-        const json = cvToJSON(getPendingSettlements(cursor));
-        expect(json.success).toBe(true);
-        const page = json.value.value as {
-          rows: {
-            value: Array<{
-              value: {
-                staker: { value: string };
-                "request-ids": { value: Array<{ value: string }> };
-              };
-            }>;
-          };
-          next: {
-            value: null | {
-              value: { staker: { value: string }; "signer-manager": { value: string } };
-            };
-          };
-        };
-
-        pageSizes.push(page.rows.value.length);
-        for (const row of page.rows.value) {
-          const staker = row.value.staker.value;
-          expect(notSettleableStakers.has(staker)).toBe(false);
-          const requestIds = row.value["request-ids"].value.map((id) => id.value);
-          expect(requestIds.length).toBeGreaterThan(0);
-          allRows.push({ staker, requestIds });
-        }
-
-        if (page.next.value === null) {
-          break;
-        }
-        const nextKey = page.next.value.value;
-        cursor = Cl.some(
-          Cl.tuple({
-            staker: Cl.principal(nextKey.staker.value),
-            "signer-manager": Cl.principal(nextKey["signer-manager"].value),
-          }),
-        );
-      }
-
-      expect(pageSizes).toEqual([95, 45]);
-      expect(allRows.map((row) => row.staker)).toEqual(expectedStakers);
-
-      const listedIds = allRows.flatMap((row) => row.requestIds.map((id) => BigInt(id)));
-      const expectedIds = expectedStakers.flatMap((staker) => idsByStaker.get(staker)!);
-      expect(listedIds.sort((a, b) => (a < b ? -1 : 1))).toEqual(
-        [...expectedIds].sort((a, b) => (a < b ? -1 : 1)),
-      );
-    },
-    300_000,
-  );
 });
 
 // Schedule / advance invariants. Several STX boundary cases are already


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/54

## Changes

* Add re-entry guards in the reward-claims registry smart contract. It is added in
    * `cancel-registration`
    * `process-reward-claim(s)`
    * `settle-pending-withdrawal(s)`
* Add a malicious signer manager smart contract to test against.
* Changed the existing authorization checks to guard against the `contract-caller` instead of the `tx-sender`.

## Testing Information

Added a bunch of unit tests to test the re-entry issue.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
