### PR TITLE
fix: handle hostile signer managers

### DIFF
--- a/contracts/contracts/malicious-signer-manager.clar
+++ b/contracts/contracts/malicious-signer-manager.clar
@@ -19,6 +19,7 @@
 (define-data-var reenter-mode uint REENTER_NONE)
 (define-data-var reenter-staker principal tx-sender)
 (define-data-var last-reenter-error (optional uint) none)
+(define-data-var withdrawal-id (optional uint) none)
 
 ;; pox-5 callback: always accept the stake.
 ;; #[allow(unnecessary_public)]
@@ -57,6 +58,7 @@
   )
 )
 
+;; #[allow(unchecked_data)]
 (define-private (note-reenter-err (err-code uint))
   (var-set last-reenter-error (some err-code))
 )
@@ -91,10 +93,12 @@
               err-v (note-reenter-err err-v)
             )
             (if (is-eq (var-get reenter-mode) REENTER_SETTLE)
-              (match (contract-call? .reward-claim-registry settle-pending-withdrawal
-                  (var-get reenter-staker)
+              (match (contract-call? .reward-claim-registry settle-pending-withdrawals
                   .mock-signer-manager
-                  u1
+                  (list {
+                    staker: (var-get reenter-staker),
+                    request-id: u1,
+                  })
                 )
                 ok-v (var-set last-reenter-error none)
                 err-v (note-reenter-err err-v)
@@ -144,7 +148,7 @@
     (attempt-reenter)
     (ok {
       earned: u0,
-      withdrawal-request: none,
+      withdrawal-request: (var-get withdrawal-id),
     })
   )
 )
@@ -199,6 +203,14 @@
     ;; #[allow(unchecked_data)]
     (var-set reenter-staker staker)
     (var-set last-reenter-error none)
+    (ok true)
+  )
+)
+
+(define-public (set-withdrawal-request (wid (optional uint)))
+  (begin
+    ;; #[allow(unchecked_data)]
+    (var-set withdrawal-id wid)
     (ok true)
   )
 )

--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -8,7 +8,7 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - **Cadence is chosen at registration.**
 - **Start cycle is explicit.** `start-reward-cycle` must be greater than or equal to the staker's `first-reward-cycle`.
 - **Catch-up is allowed.** When many distributions are already past, keepers may call `process-reward-claim` repeatedly.
-- **Always advance.** A failed `claim-rewards` or `claim-staker-rewards` still decrements `remaining-cycles`, burns one installment from escrow, and advances the schedule.
+- **Always advance.** A failed `claim-rewards` or `claim-staker-rewards` still decrements `remaining-cycles`, burns one installment from escrow, and advances the schedule. A junk or already-settled `withdrawal-request` is not stored and does not stall the claim.
 - **Self-heal pull.** If a signer manager has earned rewards in pox-5 for the reward cycle, the registry calls `claim-rewards` before `claim-staker-rewards`.
 - **Escrow then burn.** Fees are held as `prepaid-ustx` and burned one installment at a time when a claim is made. Admins do not need to escrow funds.
 - **Self-register (or admin).** Only the staker or an admin may `register-for-claims` / `add-claims`. Cancel is staker-only, including when an admin created the registration; remaining escrow is refunded to the staker.
@@ -19,5 +19,5 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
 - Only the staker may `cancel-registration` (admins cannot cancel for them). Remaining `prepaid-ustx` is refunded to the staker; pending L1 withdrawals remain settleable.
-- Pending L1 withdrawals are capped at 192 per registration; settlement is a separate permissionless step after sBTC accept/reject.
-- `get-pending-claims` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.
+- Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-settlements` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
+- `get-pending-claims` and `get-pending-settlements` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -1107,9 +1107,8 @@
 (define-private (withdrawal-ready-to-list
         (request-id uint)
         (stored-height uint)
-        (bitcoin-block-height uint)
     )
-    (if (< bitcoin-block-height (+ stored-height SETTLEMENT_MIN_BURN_AGE))
+    (if (< burn-block-height (+ stored-height SETTLEMENT_MIN_BURN_AGE))
         false
         (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
             get-withdrawal-request request-id
@@ -1257,7 +1256,6 @@
                 signer-manager: principal,
                 request-id: uint,
             }),
-            bitcoin-block-height: uint,
             rows: (list 100
                 {
                     staker: principal,
@@ -1275,9 +1273,7 @@
             )))
             (match (map-get? pending-withdrawals key)
                 stored-height
-                (if (withdrawal-ready-to-list (get request-id key) stored-height
-                        (get bitcoin-block-height acc)
-                    )
+                (if (withdrawal-ready-to-list (get request-id key) stored-height)
                     (merge acc {
                         node: next-node,
                         last-visited: (some key),
@@ -1345,7 +1341,6 @@
             (walk (fold pending-settlements-step PENDING_TICKS {
                 node: start,
                 last-visited: none,
-                bitcoin-block-height: burn-block-height,
                 rows: (list),
             }))
             (next (match (get node walk)

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -1074,10 +1074,8 @@
     )
 )
 
-;; Store only request-ids that are a live sBTC withdrawal (status none). Junk
-;; and already-settled ids are ignored so a hostile SM cannot stall the claim.
-;; Who initiated the request is not checked; the SM may route through another
-;; contract.
+;; We only want to store request-ids that are for a live sBTC withdrawal,
+;; this function does that check.
 ;; #[allow(unchecked_data)]
 (define-private (is-trackable-withdrawal (request-id uint))
     (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry get-withdrawal-request
@@ -1101,8 +1099,8 @@
     )
 )
 
-;; True when this indexed withdrawal is old enough and sBTC has resolved it
-;; (status some). Used only by get-pending-settlements; settle is ungated.
+;; Returns true when this indexed withdrawal is old enough and sBTC has
+;; resolved it. Used only by get-pending-settlements.
 ;; #[allow(unchecked_data)]
 (define-private (withdrawal-ready-to-list
         (request-id uint)
@@ -1119,9 +1117,10 @@
     )
 )
 
-;; Append `request-id` when it is a live sBTC pending withdrawal. Returns some
-;; id if tracked (stored or already present), none if skipped. Records
-;; burn-block-height and splices the 3-tuple into pending-withdrawal-ll.
+;; Append `request-id` when it is a valid sBTC pending withdrawal. Returns
+;; some id if tracked (stored or already present), none if skipped. Records
+;; burn-block-height and adds an entry into the pending-withdrawal-ll
+;; linked list.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (append-pending-withdrawal
@@ -1237,10 +1236,12 @@
     )
 )
 
-;; Fold step for get-pending-settlements. Visits one linked-list node, appends
-;; a row when the withdrawal is old enough and sBTC has resolved it, records
-;; `last-visited`, and advances `node`. Young or still-pending entries consume
-;; a tick without emitting a row. `tick` is unused; it only bounds the walk.
+;; Fold step for get-pending-settlements.
+;;
+;; Visits one linked-list node, appends a row when the withdrawal is old
+;; enough and sBTC has resolved it, records `last-visited`, and advances
+;; `node`. Young or still-pending entries do not emit a row in the
+;; accumulators rows field.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (pending-settlements-step
@@ -1307,22 +1308,24 @@
 
 ;; List indexed L1 withdrawals that are ready to settle. Walks
 ;; pending-withdrawal-ll from cursor, or from the head when cursor is none.
-;; A row is emitted only when at least SETTLEMENT_MIN_BURN_AGE Bitcoin blocks
-;; have passed since insert and sbtc-registry status is some (accepted or
-;; rejected). Younger or still-pending nodes consume walk ticks without
-;; appending a row, so a short or empty `rows` list does not mean the tail
-;; was reached. Use the returned `next` cursor: none means the walk hit the
-;; tail; some key means pass that key as the next `cursor` to resume after it.
-;; Rows are included whether or not their parent registration still exists.
+;; A row is emitted only when at least SETTLEMENT_MIN_BURN_AGE Bitcoin
+;; blocks have passed since insert and sbtc-registry status indicated that
+;; it has been accepted or rejected. Use the returned `next` cursor: none
+;; means the walk hit the tail; some key means pass that key as the next
+;; `cursor` to resume after it. Rows are included whether or not their
+;; parent registration still exists.
 ;;
 ;; Parameters:
-;;   cursor  none to start at the head, or the `next` key from the previous
-;;           page so the walk resumes at that key's successor.
+;;
+;;   cursor  use none to start at the head. When some, it indicates where
+;;           to resume looking for pending settlements. The settlement for
+;;           this key is not included in the response.
 ;;
 ;; Returns:
+;;
 ;;   ok wrapping { rows, next }. Each row has staker, signer-manager, and
-;;   request-id. `next` is none at the tail, or the last visited key when more
-;;   nodes may remain.
+;;   request-id. `next` is none at the tail, or the last visited key when
+;;   more nodes may remain.
 (define-read-only (get-pending-settlements (cursor (optional {
     staker: principal,
     signer-manager: principal,

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -2,6 +2,9 @@
 
 ;; The longest STX lock in PoX-5 is 96 reward cycles, which equals 192 distribution cycles
 (define-constant MAX_DISTRIBUTION_CYCLES u192)
+;; Minimum Bitcoin blocks after indexing before get-pending-settlements
+;; will consult sbtc-registry. Settle itself is not gated on this.
+(define-constant SETTLEMENT_MIN_BURN_AGE u7)
 
 ;; No registration for this staker and signer-manager combination
 (define-constant ERR_NOT_REGISTERED (err u600))
@@ -15,10 +18,6 @@
 (define-constant ERR_ZERO_FEE (err u604))
 ;; Nothing new to claim yet: next-claim-distribution has not fully elapsed
 (define-constant ERR_ALREADY_CLAIMED (err u605))
-;; This is thrown when there are more than 192 pending withdrawals for a
-;; registrant. This should not be reachable during PoX-5, which should not
-;; be around for more than 96 reward cycles.
-(define-constant ERR_TOO_MANY_PENDING (err u606))
 ;; The request-id is not a tracked pending withdrawal for this key
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
 ;; start-reward-cycle is before the position's first-reward-cycle
@@ -138,37 +137,45 @@
     }
 )
 
+;; One row per indexed L1 withdrawal. The value is the bitcoin block-height
+;; at which the withdrawal was indexed.
 (define-map pending-withdrawals
     {
         staker: principal,
         signer-manager: principal,
+        request-id: uint,
     }
-    (list 192 uint)
+    uint
 )
 
 (define-map pending-withdrawal-ll
     {
         staker: principal,
         signer-manager: principal,
+        request-id: uint,
     }
     {
         prev: (optional {
             staker: principal,
             signer-manager: principal,
+            request-id: uint,
         }),
         next: (optional {
             staker: principal,
             signer-manager: principal,
+            request-id: uint,
         }),
     }
 )
 (define-data-var pending-withdrawal-ll-head (optional {
     staker: principal,
     signer-manager: principal,
+    request-id: uint,
 }) none)
 (define-data-var pending-withdrawal-ll-tail (optional {
     staker: principal,
     signer-manager: principal,
+    request-id: uint,
 }) none)
 
 (define-private (min-uint
@@ -300,15 +307,16 @@
 )
 
 ;; --- Doubly-linked-list maintenance over pending-withdrawal-ll ---
-;; Same shape as the registration list, but tracking only keys with at least
-;; one outstanding withdrawal so get-pending-settlements can walk them directly.
+;; Same shape as the registration list, one node per indexed withdrawal so
+;; get-pending-settlements can walk them directly.
 
 ;; Append `key` at the tail of the pending-withdrawal list.
 ;;
 ;; #[allow(unchecked_data)]
-(define-private (pending-ll-append (key {
+(define-private (withdrawal-ll-append (key {
     staker: principal,
     signer-manager: principal,
+    request-id: uint,
 }))
     (let ((old-tail (var-get pending-withdrawal-ll-tail)))
         (map-set pending-withdrawal-ll key {
@@ -329,9 +337,10 @@
 ;; Splice `key` out of the pending-withdrawal list.
 ;;
 ;; #[allow(unchecked_data)]
-(define-private (pending-ll-remove (key {
+(define-private (withdrawal-ll-remove (key {
     staker: principal,
     signer-manager: principal,
+    request-id: uint,
 }))
     (match (map-get? pending-withdrawal-ll key)
         links (begin
@@ -938,12 +947,14 @@
     (match (signer-manager-claim-staker-rewards signer-manager staker reward-cycle bond-index)
         claim-result
         ;; paid: advance and record any L1 withdrawal for later settlement
-        (let ((withdrawal-request (get withdrawal-request claim-result)))
-            (try! (advance-registration key registration current-distribution-cycle))
-            (match withdrawal-request
-                id (try! (append-pending-withdrawal key id))
-                true
+        (let (
+                (withdrawal-request (get withdrawal-request claim-result))
+                (stored (match withdrawal-request
+                    id (append-pending-withdrawal key id)
+                    none
+                ))
             )
+            (try! (advance-registration key registration current-distribution-cycle))
             (print {
                 topic: "process-reward-claim",
                 staker: staker,
@@ -953,9 +964,9 @@
                 bond-index: bond-index,
                 earned: (get earned claim-result),
                 claim-error: none,
-                withdrawal-request: withdrawal-request,
+                withdrawal-request: stored,
             })
-            (ok withdrawal-request)
+            (ok stored)
         )
         err-code
         ;; not paid -- empty cycle, a zero share, or a claim failure. Advance
@@ -1063,9 +1074,55 @@
     )
 )
 
-;; Bookkeeping only. Appends `request-id` to key's pending-withdrawals entry
-;; (append + as-max-len? back to 192), erroring ERR_TOO_MANY_PENDING if full.
-;; Splices key into pending-withdrawal-ll if this is its first pending item.
+;; Store only request-ids that are a live sBTC withdrawal (status none). Junk
+;; and already-settled ids are ignored so a hostile SM cannot stall the claim.
+;; Who initiated the request is not checked; the SM may route through another
+;; contract.
+;; #[allow(unchecked_data)]
+(define-private (is-trackable-withdrawal (request-id uint))
+    (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry get-withdrawal-request
+        request-id
+    )
+        request (is-none (get status request))
+        false
+    )
+)
+
+;; Drop the map entry and splice the node out of pending-withdrawal-ll.
+;; #[allow(unchecked_data)]
+(define-private (remove-pending-withdrawal (key {
+    staker: principal,
+    signer-manager: principal,
+    request-id: uint,
+}))
+    (begin
+        (map-delete pending-withdrawals key)
+        (withdrawal-ll-remove key)
+    )
+)
+
+;; True when this indexed withdrawal is old enough and sBTC has resolved it
+;; (status some). Used only by get-pending-settlements; settle is ungated.
+;; #[allow(unchecked_data)]
+(define-private (withdrawal-ready-to-list
+        (request-id uint)
+        (stored-height uint)
+        (bitcoin-block-height uint)
+    )
+    (if (< bitcoin-block-height (+ stored-height SETTLEMENT_MIN_BURN_AGE))
+        false
+        (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
+            get-withdrawal-request request-id
+        )
+            request (is-some (get status request))
+            false
+        )
+    )
+)
+
+;; Append `request-id` when it is a live sBTC pending withdrawal. Returns some
+;; id if tracked (stored or already present), none if skipped. Records
+;; burn-block-height and splices the 3-tuple into pending-withdrawal-ll.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (append-pending-withdrawal
@@ -1075,17 +1132,22 @@
         })
         (request-id uint)
     )
-    (let (
-            (current (default-to (list) (map-get? pending-withdrawals key)))
-            (was-empty (is-eq current (list)))
-            (updated (unwrap! (as-max-len? (append current request-id) u192) ERR_TOO_MANY_PENDING))
+    (let ((full-key {
+            staker: (get staker key),
+            signer-manager: (get signer-manager key),
+            request-id: request-id,
+        }))
+        (if (is-trackable-withdrawal request-id)
+            (if (is-some (map-get? pending-withdrawals full-key))
+                (some request-id)
+                (begin
+                    (map-set pending-withdrawals full-key burn-block-height)
+                    (withdrawal-ll-append full-key)
+                    (some request-id)
+                )
+            )
+            none
         )
-        (map-set pending-withdrawals key updated)
-        (if was-empty
-            (pending-ll-append key)
-            true
-        )
-        (ok true)
     )
 )
 
@@ -1102,9 +1164,10 @@
 ;;
 ;; Returns:
 ;;
-;;   ok with some withdrawal request-id when an L1 withdrawal was initiated,
-;;   ok none for a direct sBTC payout or when the claim path advanced without
-;;   a payout, or an error if the registration is missing or not yet pending.
+;;   ok with some withdrawal request-id when an L1 withdrawal was stored for
+;;   later settlement, ok none for a direct sBTC payout, a skipped/invalid id,
+;;   or a claim path that advanced without a payout, or an error if the
+;;   registration is missing or not yet pending.
 ;;
 ;; #[allow(unchecked_data)]
 (define-public (process-reward-claim
@@ -1134,6 +1197,7 @@
 ;;   stakers         Up to 100 staker principals to process in order.
 ;;
 ;; Returns:
+;;
 ;;   ok with the number of stakers for which process-reward-claim-impl returned
 ;;   ok, including empty-cycle and claim-error advances.
 (define-public (process-reward-claims
@@ -1174,12 +1238,10 @@
     )
 )
 
-;; Fold step for get-pending-settlements. Reads the current node's pending
-;; request-ids, appends one row carrying the whole list, and advances `node`
-;; to the next entry. Every node in pending-withdrawal-ll has a nonempty
-;; pending-withdrawals entry (a node is spliced out when its list empties), so
-;; no filtering is needed and one row is emitted per node. Once `node` is none
-;; it is a no-op. `tick` is unused; it only bounds the iteration count.
+;; Fold step for get-pending-settlements. Visits one linked-list node, appends
+;; a row when the withdrawal is old enough and sBTC has resolved it, records
+;; `last-visited`, and advances `node`. Young or still-pending entries consume
+;; a tick without emitting a row. `tick` is unused; it only bounds the walk.
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (pending-settlements-step
@@ -1188,12 +1250,19 @@
             node: (optional {
                 staker: principal,
                 signer-manager: principal,
+                request-id: uint,
             }),
+            last-visited: (optional {
+                staker: principal,
+                signer-manager: principal,
+                request-id: uint,
+            }),
+            bitcoin-block-height: uint,
             rows: (list 100
                 {
                     staker: principal,
                     signer-manager: principal,
-                    request-ids: (list 192 uint),
+                    request-id: uint,
                 }
             ),
         })
@@ -1205,22 +1274,34 @@
                 none
             )))
             (match (map-get? pending-withdrawals key)
-                request-ids
-                (merge acc {
-                    node: next-node,
-                    rows: (default-to (get rows acc)
-                        (as-max-len?
-                            (append (get rows acc) {
-                                staker: (get staker key),
-                                signer-manager: (get signer-manager key),
-                                request-ids: request-ids,
-                            })
-                            u100
-                        )),
-                })
+                stored-height
+                (if (withdrawal-ready-to-list (get request-id key) stored-height
+                        (get bitcoin-block-height acc)
+                    )
+                    (merge acc {
+                        node: next-node,
+                        last-visited: (some key),
+                        rows: (default-to (get rows acc)
+                            (as-max-len?
+                                (append (get rows acc) {
+                                    staker: (get staker key),
+                                    signer-manager: (get signer-manager key),
+                                    request-id: (get request-id key),
+                                })
+                                u100
+                            )),
+                    })
+                    (merge acc {
+                        node: next-node,
+                        last-visited: (some key),
+                    })
+                )
                 ;; A linked-list node with no pending entry should never happen;
                 ;; skip it defensively rather than aborting the read.
-                (merge acc { node: next-node })
+                (merge acc {
+                    node: next-node,
+                    last-visited: (some key),
+                })
             )
         )
         ;; Past the tail: nothing left to visit.
@@ -1228,25 +1309,28 @@
     )
 )
 
-;; List keys with outstanding L1 withdrawal request-ids. Walks
-;; pending-withdrawal-ll from cursor, or from the head when cursor is none, and
-;; returns up to 100 rows. Every node has a nonempty pending-withdrawals entry,
-;; so each visited node yields exactly one row and a short page means the tail
-;; was reached. Rows are included whether or not their parent registration still
-;; exists. Does not check sbtc-registry status; the caller should check each
-;; request-id before paying gas to settle.
+;; List indexed L1 withdrawals that are ready to settle. Walks
+;; pending-withdrawal-ll from cursor, or from the head when cursor is none.
+;; A row is emitted only when at least SETTLEMENT_MIN_BURN_AGE Bitcoin blocks
+;; have passed since insert and sbtc-registry status is some (accepted or
+;; rejected). Younger or still-pending nodes consume walk ticks without
+;; appending a row, so a short or empty `rows` list does not mean the tail
+;; was reached. Use the returned `next` cursor: none means the walk hit the
+;; tail; some key means pass that key as the next `cursor` to resume after it.
+;; Rows are included whether or not their parent registration still exists.
 ;;
 ;; Parameters:
-;;   cursor  none to start at the head, or the last key from the previous page
-;;           so the walk resumes at that key's successor.
+;;   cursor  none to start at the head, or the `next` key from the previous
+;;           page so the walk resumes at that key's successor.
 ;;
 ;; Returns:
-;;   ok wrapping a list of rows. Each row has staker, signer-manager, and
-;;   request-ids, every sbtc-registry request-id awaiting settlement for that
-;;   key, up to 192.
+;;   ok wrapping { rows, next }. Each row has staker, signer-manager, and
+;;   request-id. `next` is none at the tail, or the last visited key when more
+;;   nodes may remain.
 (define-read-only (get-pending-settlements (cursor (optional {
     staker: principal,
     signer-manager: principal,
+    request-id: uint,
 })))
     (let (
             ;; Resume just after `cursor` (the last key the caller handled), or
@@ -1258,42 +1342,35 @@
                 )
                 (var-get pending-withdrawal-ll-head)
             ))
-        )
-        ;; PENDING_TICKS is the elided (list 100 uint) bounding the walk to at most
-        ;; 100 node visits per call.
-        (ok (get rows
-            (fold pending-settlements-step PENDING_TICKS {
+            (walk (fold pending-settlements-step PENDING_TICKS {
                 node: start,
+                last-visited: none,
+                bitcoin-block-height: burn-block-height,
                 rows: (list),
-            })
-        ))
-    )
-)
-
-;; Fold step for settle-pending-withdrawal-impl: drops `target` from the list
-;; being rebuilt, recording whether it was found.
-(define-private (pending-withdrawal-fold-step
-        (request-id uint)
-        (acc {
-            target: uint,
-            found: bool,
-            kept: (list 192 uint),
+            }))
+            (next (match (get node walk)
+                more-to-do (get last-visited walk)
+                none
+            ))
+        )
+        (ok {
+            rows: (get rows walk),
+            next: next,
         })
-    )
-    (if (is-eq request-id (get target acc))
-        (merge acc { found: true })
-        (merge acc { kept: (default-to (get kept acc) (as-max-len? (append (get kept acc) request-id) u192)) })
     )
 )
 
 ;; Shared by settle-pending-withdrawal and the batch fold below. Reads the
 ;; pending item's status from sbtc-registry and:
-;;   pending (status none)     no-op. Calling early just costs the caller's gas.
-;;   accepted (some true)      calls signer-manager::settle-accepted-withdrawal.
-;;   rejected (some false)     calls signer-manager::reclaim-failed-withdrawal.
-;; Either resolved case removes the request-id from pending-withdrawals (deleting
-;; the entry and splicing out of pending-withdrawal-ll if that empties the list).
-;; No STX moves. Returns whether it resolved (true) or was still pending (false).
+;;
+;;   not indexed               ERR_UNKNOWN_PENDING_WITHDRAWAL
+;;   unknown to sbtc-registry  prune the id (ok true)
+;;   pending (none)            no-op (ok false)
+;;   accepted (some true)      call settle-accepted-withdrawal, always prune
+;;   rejected (some false)     call reclaim-failed-withdrawal, always prune
+;;
+;; SM errors do not influence our behavior. Returns whether the id was
+;; removed (true) or is still pending (false).
 ;;
 ;; #[allow(unchecked_data)]
 (define-private (settle-pending-withdrawal-impl
@@ -1301,58 +1378,51 @@
         (signer-manager <reward-claim-signer-manager-trait>)
         (request-id uint)
     )
-    (let (
-            (key {
-                staker: staker,
-                signer-manager: (contract-of signer-manager),
-            })
-            (current (unwrap! (map-get? pending-withdrawals key) ERR_UNKNOWN_PENDING_WITHDRAWAL))
-            (fold-result (fold pending-withdrawal-fold-step current {
-                target: request-id,
-                found: false,
-                kept: (list),
-            }))
-            (request (unwrap!
-                (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
-                    get-withdrawal-request request-id
-                )
-                ERR_UNKNOWN_PENDING_WITHDRAWAL
-            ))
+    (let ((key {
+            staker: staker,
+            signer-manager: (contract-of signer-manager),
+            request-id: request-id,
+        }))
+        (asserts! (is-some (map-get? pending-withdrawals key)) ERR_UNKNOWN_PENDING_WITHDRAWAL)
+        (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
+            get-withdrawal-request request-id
         )
-        (asserts! (get found fold-result) ERR_UNKNOWN_PENDING_WITHDRAWAL)
-        (match (get status request)
-            accepted (begin
-                (if accepted
-                    (try! (signer-manager-settle-accepted-withdrawal signer-manager request-id))
-                    (try! (signer-manager-reclaim-failed-withdrawal signer-manager request-id))
-                )
-                (if (is-eq (get kept fold-result) (list))
-                    (begin
-                        (map-delete pending-withdrawals key)
-                        (pending-ll-remove key)
+            request (match (get status request)
+                accepted (begin
+                    (if accepted
+                        (is-ok (signer-manager-settle-accepted-withdrawal signer-manager request-id))
+                        (is-ok (signer-manager-reclaim-failed-withdrawal signer-manager request-id))
                     )
-                    (map-set pending-withdrawals key (get kept fold-result))
+                    (remove-pending-withdrawal key)
+                    (print {
+                        topic: "settle-pending-withdrawal",
+                        staker: staker,
+                        signer-manager: (contract-of signer-manager),
+                        request-id: request-id,
+                        accepted: accepted,
+                    })
+                    (ok true)
                 )
+                (ok false)
+            )
+            (begin
+                (remove-pending-withdrawal key)
                 (print {
-                    topic: "settle-pending-withdrawal",
+                    topic: "prune-pending-withdrawal",
                     staker: staker,
                     signer-manager: (contract-of signer-manager),
                     request-id: request-id,
-                    accepted: accepted,
                 })
                 (ok true)
             )
-            (ok false)
         )
     )
 )
 
 ;; Resolve one pending withdrawal. Reads its status from sbtc-registry. When
-;; status is none the call is a no-op. When accepted, calls the signer-manager's
-;; settle-accepted-withdrawal. When rejected, calls reclaim-failed-withdrawal.
-;; Either resolved case removes the request-id from pending-withdrawals and
-;; splices the key out of pending-withdrawal-ll if that list becomes empty.
-;; Permissionless; the caller pays gas and receives nothing.
+;; the id is unknown to sbtc-registry it is pruned. When status is none the
+;; call is a no-op. When accepted or rejected, calls the signer-manager then
+;; always removes the id (even if the SM errors).
 ;;
 ;; Parameters:
 ;;   staker          The staker on the pending-withdrawal key.
@@ -1360,9 +1430,9 @@
 ;;   request-id      The sbtc-registry withdrawal request-id to settle.
 ;;
 ;; Returns:
-;;   ok true if the withdrawal was accepted or rejected and removed from the
-;;   pending list, ok false if it is still pending in sbtc-registry, or an
-;;   error if the request-id is not tracked for this key.
+;;   ok true if the id was removed (settled, pruned, or SM error), ok false if
+;;   it is still pending in sbtc-registry, or an error if the request-id is not
+;;   tracked for this staker and signer-manager.
 ;;
 ;; #[allow(unchecked_data)]
 (define-public (settle-pending-withdrawal
@@ -1386,7 +1456,7 @@
 ;;   items           Up to 100 tuples of staker and request-id.
 ;;
 ;; Returns:
-;;   ok with the number of items that resolved to accepted or rejected.
+;;   ok with the number of items that were removed from the pending list.
 (define-public (settle-pending-withdrawals
         (signer-manager <reward-claim-signer-manager-trait>)
         (items (list 100 {

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -656,7 +656,7 @@ export function getPendingClaims(cursor: OptionalCV = Cl.none()) {
   ).result;
 }
 
-export function getPendingSettlements(cursor = Cl.none()) {
+export function getPendingSettlements(cursor: OptionalCV = Cl.none()) {
   return simnet.callReadOnlyFn(
     "reward-claim-registry",
     "get-pending-settlements",

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -370,6 +370,15 @@ export function setMaliciousReenterMode(mode: bigint, staker: string) {
   );
 }
 
+export function setMaliciousWithdrawalRequest(wid: OptionalCV<UIntCV>) {
+  return simnet.callPublicFn(
+    "malicious-signer-manager",
+    "set-withdrawal-request",
+    [wid],
+    deployer,
+  );
+}
+
 export function getMaliciousLastReenterError() {
   return simnet.callReadOnlyFn(
     "malicious-signer-manager",

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -79,7 +79,6 @@ export const ERR_NOT_ADMIN = 602n;
 export const ERR_NO_CURRENT_POSITION = 603n;
 export const ERR_ZERO_FEE = 604n;
 export const ERR_ALREADY_CLAIMED = 605n;
-export const ERR_TOO_MANY_PENDING = 606n;
 export const ERR_UNKNOWN_PENDING_WITHDRAWAL = 607n;
 export const ERR_INVALID_START_REWARD_CYCLE = 608n;
 export const ERR_UNAUTHORIZED = 609n;
@@ -113,6 +112,14 @@ export function mineUntil(target: bigint) {
   if (target > current) {
     simnet.mineEmptyBurnBlocks(Number(target - current));
   }
+}
+
+/** Bitcoin blocks after indexing before get-pending-settlements consults sBTC. */
+export const SETTLEMENT_MIN_BURN_AGE = 7n;
+
+/** Mine enough burn blocks for an indexed withdrawal to pass the listing age gate. */
+export function mineUntilSettlementListable() {
+  simnet.mineEmptyBurnBlocks(Number(SETTLEMENT_MIN_BURN_AGE));
 }
 
 export function rewardCycleToBurnHeight(cycle: bigint): bigint {
@@ -678,6 +685,16 @@ export function rejectWithdrawal(requestId: bigint) {
     "reject-withdrawal-request",
     [Cl.uint(requestId), Cl.uint(0)],
     SBTC_SIGNER,
+  );
+}
+
+/** Direct signer-manager settle; deletes its map entry without touching the registry. */
+export function settleAcceptedWithdrawalOnSignerManager(requestId: bigint, sender: string) {
+  return simnet.callPublicFn(
+    "signer-manager",
+    "settle-accepted-withdrawal",
+    [Cl.uint(requestId)],
+    sender,
   );
 }
 

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -50,6 +50,7 @@ import {
   rejectWithdrawal,
   sbtcBalance,
   setMaliciousReenterMode,
+  setMaliciousWithdrawalRequest,
   setMockClaimRewardsResult,
   setMockClaimStakerResult,
   settleAcceptedWithdrawalOnSignerManager,
@@ -1013,8 +1014,10 @@ describe("L1 withdrawal path + settlements", () => {
     initPox5();
     registerSignerManager(SIGNER_PRIVATE_KEY);
     stakeWithPoxAddr(wallet1, SIGNER_SET_MIN_USTX, 2n, 100n);
+    stakeWithPoxAddr(wallet2, SIGNER_SET_MIN_USTX, 2n, 100n);
     fundAndClaimSignerRewards(2000n, 1n);
     registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
   });
 
@@ -1101,6 +1104,23 @@ describe("L1 withdrawal path + settlements", () => {
     expect(result).toBeOk(Cl.uint(1));
     mineUntilSettlementListable();
     expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+  });
+
+  it("process-reward-claims records withdrawal request-ids", () => {
+    const { result } = simnet.callPublicFn(
+      "reward-claim-registry",
+      "process-reward-claims",
+      [Cl.principal(SIGNER_MANAGER), Cl.list([Cl.principal(wallet1), Cl.principal(wallet2)])],
+      wallet3,
+    );
+    expect(result).toBeOk(Cl.uint(2));
+
+    acceptWithdrawal(1n, 30n);
+    acceptWithdrawal(2n, 30n);
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([settlementRow(wallet1, 1n), settlementRow(wallet2, 2n)]),
+    );
   });
 });
 
@@ -1243,6 +1263,79 @@ describe("get-pending-settlements pagination", () => {
 
       expect(pageSizes).toEqual([95, 93, 19]);
       expect(listedIds).toEqual(expectedIds);
+    },
+    300_000,
+  );
+
+  it(
+    "returns empty rows with next set when the first 100 nodes are not settleable",
+    () => {
+      const TOTAL = 101;
+      initPox5();
+      registerSignerManager(SIGNER_PRIVATE_KEY);
+
+      const stakers = Array.from({ length: TOTAL }, (_, i) => {
+        const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+        return privateKeyToAddress(hex, "testnet");
+      });
+
+      for (const staker of stakers) {
+        expect(
+          simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+        ).toBeOk(Cl.bool(true));
+        stakeWithPoxAddr(staker, SIGNER_SET_MIN_USTX, 2n, 100n);
+        expect(
+          registerForClaims(staker, FEE_PER_CLAIM, deployer, SIGNER_MANAGER, STX_START, true)
+            .result,
+        ).toBeOk(Cl.uint(1));
+      }
+
+      fundAndClaimSignerRewards(500_000n, 1n);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+
+      for (let i = 0; i < TOTAL; i++) {
+        expect(processRewardClaim(stakers[i]!, deployer, SIGNER_MANAGER).result).toBeOk(
+          Cl.some(Cl.uint(BigInt(i + 1))),
+        );
+      }
+
+      const lastId = BigInt(TOTAL);
+      const lastStaker = stakers[TOTAL - 1]!;
+      expect(acceptWithdrawal(lastId, 30n).result).toBeOk(Cl.bool(true));
+      mineUntilSettlementListable();
+
+      const first = cvToJSON(getPendingSettlements()) as {
+        success: boolean;
+        value: {
+          value: {
+            rows: { value: unknown[] };
+            next: {
+              value: null | {
+                value: {
+                  staker: { value: string };
+                  "signer-manager": { value: string };
+                  "request-id": { value: string };
+                };
+              };
+            };
+          };
+        };
+      };
+      expect(first.success).toBe(true);
+      expect(first.value.value.rows.value).toHaveLength(0);
+      expect(first.value.value.next.value).not.toBeNull();
+
+      const nextKey = first.value.value.next.value!.value;
+      const second = getPendingSettlements(
+        Cl.some(
+          Cl.tuple({
+            staker: Cl.principal(nextKey.staker.value),
+            "signer-manager": Cl.principal(nextKey["signer-manager"].value),
+            "request-id": Cl.uint(BigInt(nextKey["request-id"].value)),
+          }),
+        ),
+      );
+      expect(second).toBeOk(pendingSettlementsPage([settlementRow(lastStaker, lastId)]));
     },
     300_000,
   );
@@ -1477,7 +1570,7 @@ describe("reentrancy", () => {
     expect(stxBalance(wallet1)).toBe(before);
   });
 
-  it("blocks settle-pending-withdrawal reentry from claim-staker-rewards", () => {
+  it("blocks settle-pending-withdrawals reentry from claim-staker-rewards", () => {
     setMaliciousReenterMode(REENTER_SETTLE, wallet1);
     expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
       Cl.none(),
@@ -1514,6 +1607,51 @@ describe("reentrancy", () => {
     );
     expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_UNAUTHORIZED));
     expectSingleAdvance();
+  });
+});
+
+describe("reentrancy from settle-accepted-withdrawal", () => {
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    registerMaliciousSignerManager();
+    stakeWithPoxAddr(wallet2, SIGNER_SET_MIN_USTX, 2n, 100n);
+    stakeForMalicious(wallet1, SIGNER_SET_MIN_USTX, 4n);
+    fundAndClaimSignerRewards(2000n, 1n);
+    registerForClaims(wallet2, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(
+      wallet1,
+      3n * FEE_PER_CLAIM,
+      wallet1,
+      MALICIOUS_SIGNER_MANAGER,
+      STX_START,
+      true,
+    );
+    mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+
+    expect(processRewardClaim(wallet2, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
+    setMaliciousWithdrawalRequest(Cl.some(Cl.uint(1)));
+    expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
+      Cl.some(Cl.uint(1)),
+    );
+    acceptWithdrawal(1n, 30n);
+  });
+
+  it("blocks settle-pending-withdrawals reentry from settle-accepted-withdrawal", () => {
+    setMaliciousReenterMode(REENTER_SETTLE, wallet1);
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "settle-pending-withdrawal",
+        [Cl.principal(wallet1), Cl.principal(MALICIOUS_SIGNER_MANAGER), Cl.uint(1)],
+        wallet3,
+      ).result,
+    ).toBeOk(Cl.bool(true));
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([settlementRow(wallet2, 1n)]),
+    );
   });
 });
 

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -1104,6 +1104,150 @@ describe("L1 withdrawal path + settlements", () => {
   });
 });
 
+describe("get-pending-settlements pagination", () => {
+  it(
+    "paginates past not-yet-settleable withdrawals across >100 ids (Rust get_all style)",
+    () => {
+      // 150 stakers on pending-withdrawal-ll; 70 of them get a second claim so
+      // there are 220 withdrawal IDs (one LL node each). 10 stakers stay
+      // status-none: 5 of those first-claim nodes sit in the first 100 visits
+      // and 5 in the next 50. Dual-claim ids append after the 150 first-claims.
+      // PENDING_TICKS=100, so three pages of settleable rows: 95 + 93 + 19.
+      const TOTAL_STAKERS = 150;
+      const DUAL_CLAIM_COUNT = 70; // 150 + 70 = 220 withdrawal IDs
+      const notSettleable = new Set([10, 30, 50, 70, 90, 110, 130, 140, 145, 149]);
+
+      initPox5();
+      registerSignerManager(SIGNER_PRIVATE_KEY);
+
+      const stakers = Array.from({ length: TOTAL_STAKERS }, (_, i) => {
+        const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+        return privateKeyToAddress(hex, "testnet");
+      });
+
+      for (let i = 0; i < TOTAL_STAKERS; i++) {
+        const staker = stakers[i]!;
+        expect(
+          simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+        ).toBeOk(Cl.bool(true));
+        stakeWithPoxAddr(staker, SIGNER_SET_MIN_USTX, 6n, 100n);
+        expect(
+          registerForClaims(
+            staker,
+            3n * FEE_PER_CLAIM,
+            deployer,
+            SIGNER_MANAGER,
+            STX_START,
+            true,
+          ).result,
+        ).toBeOk(Cl.uint(3));
+      }
+
+      fundAndClaimSignerRewards(500_000n, 1n);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+
+      const idsByStaker = new Map<string, bigint[]>();
+      const readWithdrawalId = (result: ClarityValue): bigint => {
+        const json = cvToJSON(result) as {
+          success: boolean;
+          value: { value: { value: string } };
+        };
+        expect(json.success).toBe(true);
+        return BigInt(json.value.value.value);
+      };
+
+      for (const staker of stakers) {
+        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
+        idsByStaker.set(staker, [readWithdrawalId(result)]);
+      }
+
+      fundAndClaimSignerRewards(500_000n, 2n);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST + 2n);
+
+      for (let i = 0; i < DUAL_CLAIM_COUNT; i++) {
+        const staker = stakers[i]!;
+        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
+        idsByStaker.get(staker)!.push(readWithdrawalId(result));
+      }
+
+      const allIds = [...idsByStaker.values()].flat();
+      expect(allIds).toHaveLength(220);
+      expect(new Set(allIds).size).toBe(220);
+
+      for (let i = 0; i < TOTAL_STAKERS; i++) {
+        if (notSettleable.has(i)) continue;
+        for (const id of idsByStaker.get(stakers[i]!)!) {
+          expect(rejectWithdrawal(id).result).toBeOk(Cl.bool(true));
+        }
+      }
+
+      mineUntilSettlementListable();
+
+      const expectedIds: bigint[] = [];
+      for (let i = 0; i < TOTAL_STAKERS; i++) {
+        if (!notSettleable.has(i)) expectedIds.push(idsByStaker.get(stakers[i]!)![0]!);
+      }
+      for (let i = 0; i < DUAL_CLAIM_COUNT; i++) {
+        if (!notSettleable.has(i)) expectedIds.push(idsByStaker.get(stakers[i]!)![1]!);
+      }
+      expect(expectedIds).toHaveLength(207);
+
+      const notSettleableStakers = new Set(
+        [...notSettleable].map((i) => stakers[i]!),
+      );
+
+      const listedIds: bigint[] = [];
+      let cursor: OptionalCV = Cl.none();
+      const pageSizes: number[] = [];
+      for (let guard = 0; guard < 10; guard++) {
+        const json = cvToJSON(getPendingSettlements(cursor));
+        expect(json.success).toBe(true);
+        const page = json.value.value as {
+          rows: {
+            value: Array<{
+              value: {
+                staker: { value: string };
+                "request-id": { value: string };
+              };
+            }>;
+          };
+          next: {
+            value: null | {
+              value: {
+                staker: { value: string };
+                "signer-manager": { value: string };
+                "request-id": { value: string };
+              };
+            };
+          };
+        };
+
+        pageSizes.push(page.rows.value.length);
+        for (const row of page.rows.value) {
+          expect(notSettleableStakers.has(row.value.staker.value)).toBe(false);
+          listedIds.push(BigInt(row.value["request-id"].value));
+        }
+
+        if (page.next.value === null) {
+          break;
+        }
+        const nextKey = page.next.value.value;
+        cursor = Cl.some(
+          Cl.tuple({
+            staker: Cl.principal(nextKey.staker.value),
+            "signer-manager": Cl.principal(nextKey["signer-manager"].value),
+            "request-id": Cl.uint(BigInt(nextKey["request-id"].value)),
+          }),
+        );
+      }
+
+      expect(pageSizes).toEqual([95, 93, 19]);
+      expect(listedIds).toEqual(expectedIds);
+    },
+    300_000,
+  );
+});
+
 // Schedule / advance invariants. Several STX boundary cases are already
 // covered above; this suite tests catch-up, bond cadence, the desired
 // past-cycle bond skip, and mock SM error advance.

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -41,6 +41,7 @@ import {
   initPox5,
   registerMaliciousSignerManager,
   mineUntilPastDistribution,
+  mineUntilSettlementListable,
   processRewardClaim,
   registerForBond,
   registerForClaims,
@@ -51,7 +52,7 @@ import {
   setMaliciousReenterMode,
   setMockClaimRewardsResult,
   setMockClaimStakerResult,
-  setMockSettleResult,
+  settleAcceptedWithdrawalOnSignerManager,
   setupBond,
   stakeFor,
   stakeForMalicious,
@@ -137,11 +138,21 @@ function pendingClaimsPage(
   });
 }
 
-function settlement(staker: string, requestIds: bigint[]) {
+function settlementRow(staker: string, requestId: bigint, signerManager = SIGNER_MANAGER) {
   return Cl.tuple({
-    "staker": Cl.principal(staker),
-    "signer-manager": Cl.principal(SIGNER_MANAGER),
-    "request-ids": Cl.list(requestIds.map((id) => Cl.uint(id))),
+    staker: Cl.principal(staker),
+    "signer-manager": Cl.principal(signerManager),
+    "request-id": Cl.uint(requestId),
+  });
+}
+
+function pendingSettlementsPage(
+  rows: ReturnType<typeof settlementRow>[],
+  next: ClarityValue = Cl.none(),
+) {
+  return Cl.tuple({
+    rows: Cl.list(rows),
+    next,
   });
 }
 
@@ -499,7 +510,6 @@ describe("cancel-registration", () => {
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
 
     expect(processRewardClaim(wallet2, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet2, [1n])]));
 
     expect(
       simnet.callPublicFn(
@@ -510,9 +520,12 @@ describe("cancel-registration", () => {
       ).result,
     ).toBeOk(Cl.uint(2n * FEE_PER_CLAIM));
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet2, [1n])]));
 
     acceptWithdrawal(1n, 30n);
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([settlementRow(wallet2, 1n)]),
+    );
     expect(
       simnet.callPublicFn(
         "reward-claim-registry",
@@ -521,7 +534,7 @@ describe("cancel-registration", () => {
         wallet3,
       ).result,
     ).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 });
 
@@ -1005,10 +1018,24 @@ describe("L1 withdrawal path + settlements", () => {
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
   });
 
-  it("records a withdrawal request-id and lists it as a pending settlement", () => {
+  it("records a withdrawal request-id and lists it once accepted and old enough", () => {
     const { result } = processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet1, [1n])]));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+
+    acceptWithdrawal(1n, 30n);
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([settlementRow(wallet1, 1n)]),
+    );
+  });
+
+  it("does not list a still-pending withdrawal even after the age gate", () => {
+    processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("settles an ACCEPTED withdrawal and clears it from the settlement list", () => {
@@ -1016,7 +1043,8 @@ describe("L1 withdrawal path + settlements", () => {
     acceptWithdrawal(1n, 30n);
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("settles a REJECTED withdrawal (reclaims to the staker) and clears it", () => {
@@ -1024,13 +1052,15 @@ describe("L1 withdrawal path + settlements", () => {
     rejectWithdrawal(1n);
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("is a no-op while the withdrawal is still pending", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeOk(Cl.bool(false));
-    expect(getPendingSettlements()).toBeOk(Cl.list([settlement(wallet1, [1n])]));
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("errors on an unknown pending withdrawal", () => {
@@ -1038,6 +1068,19 @@ describe("L1 withdrawal path + settlements", () => {
     expect(settlePendingWithdrawal(wallet1, 9999n, wallet2).result).toBeErr(
       Cl.uint(ERR_UNKNOWN_PENDING_WITHDRAWAL),
     );
+  });
+
+  it("prunes a registry id after the signer-manager already settled it", () => {
+    processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
+    acceptWithdrawal(1n, 30n);
+    expect(settleAcceptedWithdrawalOnSignerManager(1n, wallet2).result).toBeOk(Cl.bool(true));
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([settlementRow(wallet1, 1n)]),
+    );
+
+    expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeOk(Cl.bool(true));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 
   it("batch settle-pending-withdrawals resolves accepted items and counts them", () => {
@@ -1056,7 +1099,8 @@ describe("L1 withdrawal path + settlements", () => {
       wallet2,
     );
     expect(result).toBeOk(Cl.uint(1));
-    expect(getPendingSettlements()).toBeOk(Cl.list([]));
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
   });
 });
 
@@ -1215,6 +1259,18 @@ describe("claim schedule invariants", () => {
       );
     });
 
+    it("skips a junk withdrawal-request id and still advances", () => {
+      setMockClaimStakerResult(false, 1001n, 1000n, Cl.some(Cl.uint(9999)));
+      registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet1, MOCK_SIGNER_MANAGER, STX_START, true);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+
+      expect(processRewardClaim(wallet1, wallet1, MOCK_SIGNER_MANAGER).result).toBeOk(Cl.none());
+      expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+      expect(getRegistration(wallet1, MOCK_SIGNER_MANAGER)).toBeSome(
+        stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
+      );
+    });
+
     it("decrements when claim-rewards succeeds but claim-staker-rewards errors", () => {
       fundAndCalculateRewards(2000n, 1n);
       expect(getEarned(MOCK_SIGNER_MANAGER, 1n, Cl.none())).toBeGreaterThan(0n);
@@ -1317,66 +1373,86 @@ describe("reentrancy", () => {
   });
 });
 
-describe("batch settle SM error does not stick the reentrancy lock", () => {
+describe("withdrawal-request ids that are not a live sBTC pending request", () => {
   beforeEach(() => {
     initPox5();
     registerSignerManager(SIGNER_PRIVATE_KEY);
     registerMockSignerManager();
-    stakeWithPoxAddr(wallet2, SIGNER_SET_MIN_USTX, 2n, 100n);
+    stakeWithPoxAddr(wallet1, SIGNER_SET_MIN_USTX, 2n, 100n);
     stakeForMock(wallet3, SIGNER_SET_MIN_USTX, 4n);
-    registerForClaims(wallet2, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
-    registerForClaims(wallet3, 3n * FEE_PER_CLAIM, wallet3, MOCK_SIGNER_MANAGER, STX_START, true);
     fundAndClaimSignerRewards(2000n, 1n);
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet3, 3n * FEE_PER_CLAIM, wallet3, MOCK_SIGNER_MANAGER, STX_START, true);
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
   });
 
-  it("batch settle-pending-withdrawals still allows later gated calls after the SM errors", () => {
-    // Real L1 withdrawal so sbtc-registry has request-id 1 with an accepted status.
-    expect(processRewardClaim(wallet2, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
-    acceptWithdrawal(1n, 30n);
-
-    // Mock SM tracks that same request-id so settle dispatches to the mock.
+  it("stores a live withdrawal id even if another signer-manager created it", () => {
+    expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
     setMockClaimStakerResult(false, 1001n, 1000n, Cl.some(Cl.uint(1)));
     expect(processRewardClaim(wallet3, wallet3, MOCK_SIGNER_MANAGER).result).toBeOk(
       Cl.some(Cl.uint(1)),
     );
+    acceptWithdrawal(1n, 30n);
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([
+        settlementRow(wallet1, 1n),
+        settlementRow(wallet3, 1n, MOCK_SIGNER_MANAGER),
+      ]),
+    );
+    expect(getRegistration(wallet3, MOCK_SIGNER_MANAGER)).toBeSome(
+      stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
+    );
+  });
 
-    setMockSettleResult(true, 4242n);
+  it("does not store an already-accepted withdrawal id", () => {
+    expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
+    acceptWithdrawal(1n, 30n);
+    setMockClaimStakerResult(false, 1001n, 1000n, Cl.some(Cl.uint(1)));
+    expect(processRewardClaim(wallet3, wallet3, MOCK_SIGNER_MANAGER).result).toBeOk(Cl.none());
+    mineUntilSettlementListable();
+    expect(getPendingSettlements()).toBeOk(
+      pendingSettlementsPage([settlementRow(wallet1, 1n)]),
+    );
+  });
+});
+
+describe("batch settle SM error does not stick the reentrancy lock", () => {
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    stakeWithPoxAddr(wallet1, SIGNER_SET_MIN_USTX, 2n, 100n);
+    fundAndClaimSignerRewards(2000n, 1n);
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+  });
+
+  it("batch settle-pending-withdrawals still allows later gated calls after the SM errors", () => {
+    expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
+    acceptWithdrawal(1n, 30n);
+    expect(settleAcceptedWithdrawalOnSignerManager(1n, wallet2).result).toBeOk(Cl.bool(true));
+
     expect(
       simnet.callPublicFn(
         "reward-claim-registry",
         "settle-pending-withdrawals",
         [
-          Cl.principal(MOCK_SIGNER_MANAGER),
+          Cl.principal(SIGNER_MANAGER),
           Cl.list([
-            Cl.tuple({ staker: Cl.principal(wallet3), "request-id": Cl.uint(1) }),
+            Cl.tuple({ staker: Cl.principal(wallet1), "request-id": Cl.uint(1) }),
           ]),
         ],
         wallet2,
       ).result,
-    ).toBeOk(Cl.uint(0));
+    ).toBeOk(Cl.uint(1));
+    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
 
-    // Lock was cleared: the SM error surfaces, not ERR_REENTRANT_CALL.
-    expect(
-      simnet.callPublicFn(
-        "reward-claim-registry",
-        "settle-pending-withdrawal",
-        [Cl.principal(wallet3), Cl.principal(MOCK_SIGNER_MANAGER), Cl.uint(1)],
-        wallet2,
-      ).result,
-    ).toBeErr(Cl.uint(4242));
-    expect(processRewardClaim(wallet3, wallet3, MOCK_SIGNER_MANAGER).result).toBeErr(
+    // Lock was cleared: the SM error was swallowed and the id pruned.
+    expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeErr(
       Cl.uint(ERR_ALREADY_CLAIMED),
     );
-
-    setMockSettleResult(false);
-    expect(
-      simnet.callPublicFn(
-        "reward-claim-registry",
-        "settle-pending-withdrawal",
-        [Cl.principal(wallet3), Cl.principal(MOCK_SIGNER_MANAGER), Cl.uint(1)],
-        wallet2,
-      ).result,
-    ).toBeOk(Cl.bool(true));
+    expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeErr(
+      Cl.uint(ERR_UNKNOWN_PENDING_WITHDRAWAL),
+    );
   });
 });


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/56 and closes https://github.com/stx-labs/spox/issues/51

## Changes

* Refactored how we store withdrawal IDs that will need handling.
* Check whether the withdrawal request ID returned from the signer manager is a genuine ID for a request that hasn't been fulfilled.
* `get-pending-settlements` checks whether the withdrawal request has been accepted or rejected by the sBTC signers before returning it.
* Do not bail if the signer manager returns an error. Instead, ignore their response and delete the key from our contract.

## Testing Information

Added a bunch of unit tests.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
