### PR TITLE
refactor: rename settlements to withdrawals

### DIFF
--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -19,5 +19,5 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
 - Only the staker may `cancel-registration` (admins cannot cancel for them). Remaining `prepaid-ustx` is refunded to the staker; pending L1 withdrawals remain settleable.
-- Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-settlements` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
-- `get-pending-claims` and `get-pending-settlements` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.
+- Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-withdrawals` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
+- `get-pending-claims` and `get-pending-withdrawals` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -2,9 +2,9 @@
 
 ;; The longest STX lock in PoX-5 is 96 reward cycles, which equals 192 distribution cycles
 (define-constant MAX_DISTRIBUTION_CYCLES u192)
-;; Minimum Bitcoin blocks after indexing before get-pending-settlements
+;; Minimum Bitcoin blocks after indexing before get-pending-withdrawals
 ;; will consult sbtc-registry. Settle itself is not gated on this.
-(define-constant SETTLEMENT_MIN_BURN_AGE u7)
+(define-constant WITHDRAWAL_MIN_BURN_AGE u7)
 
 ;; No registration for this staker and signer-manager combination
 (define-constant ERR_NOT_REGISTERED (err u600))
@@ -34,7 +34,7 @@
 (define-constant ERR_REENTRANT_CALL (err u612))
 
 ;; A (list 100 uint) whose only job is to bound the get-pending-claims /
-;; get-pending-settlements folds to at most 100 node visits per call. The
+;; get-pending-withdrawals folds to at most 100 node visits per call. The
 ;; element values are never read (the fold step ignores `tick`).
 ;; @format-ignore
 (define-constant PENDING_TICKS (list
@@ -308,7 +308,7 @@
 
 ;; --- Doubly-linked-list maintenance over pending-withdrawal-ll ---
 ;; Same shape as the registration list, one node per indexed withdrawal so
-;; get-pending-settlements can walk them directly.
+;; get-pending-withdrawals can walk them directly.
 
 ;; Append `key` at the tail of the pending-withdrawal list.
 ;;
@@ -1100,13 +1100,13 @@
 )
 
 ;; Returns true when this indexed withdrawal is old enough and sBTC has
-;; resolved it. Used only by get-pending-settlements.
+;; resolved it. Used only by get-pending-withdrawals.
 ;; #[allow(unchecked_data)]
 (define-private (withdrawal-ready-to-list
         (request-id uint)
         (stored-height uint)
     )
-    (if (< burn-block-height (+ stored-height SETTLEMENT_MIN_BURN_AGE))
+    (if (< burn-block-height (+ stored-height WITHDRAWAL_MIN_BURN_AGE))
         false
         (match (contract-call? 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-registry
             get-withdrawal-request request-id
@@ -1236,7 +1236,7 @@
     )
 )
 
-;; Fold step for get-pending-settlements.
+;; Fold step for get-pending-withdrawals.
 ;;
 ;; Visits one linked-list node, appends a row when the withdrawal is old
 ;; enough and sBTC has resolved it, records `last-visited`, and advances
@@ -1244,7 +1244,7 @@
 ;; accumulators rows field.
 ;;
 ;; #[allow(unchecked_data)]
-(define-private (pending-settlements-step
+(define-private (pending-withdrawals-step
         (tick_ uint)
         (acc {
             node: (optional {
@@ -1308,7 +1308,7 @@
 
 ;; List indexed L1 withdrawals that are ready to settle. Walks
 ;; pending-withdrawal-ll from cursor, or from the head when cursor is none.
-;; A row is emitted only when at least SETTLEMENT_MIN_BURN_AGE Bitcoin
+;; A row is emitted only when at least WITHDRAWAL_MIN_BURN_AGE Bitcoin
 ;; blocks have passed since insert and sbtc-registry status indicated that
 ;; it has been accepted or rejected. Use the returned `next` cursor: none
 ;; means the walk hit the tail; some key means pass that key as the next
@@ -1318,7 +1318,7 @@
 ;; Parameters:
 ;;
 ;;   cursor  use none to start at the head. When some, it indicates where
-;;           to resume looking for pending settlements. The settlement for
+;;           to resume looking for pending withdrawals. The withdrawal for
 ;;           this key is not included in the response.
 ;;
 ;; Returns:
@@ -1326,7 +1326,7 @@
 ;;   ok wrapping { rows, next }. Each row has staker, signer-manager, and
 ;;   request-id. `next` is none at the tail, or the last visited key when
 ;;   more nodes may remain.
-(define-read-only (get-pending-settlements (cursor (optional {
+(define-read-only (get-pending-withdrawals (cursor (optional {
     staker: principal,
     signer-manager: principal,
     request-id: uint,
@@ -1341,7 +1341,7 @@
                 )
                 (var-get pending-withdrawal-ll-head)
             ))
-            (walk (fold pending-settlements-step PENDING_TICKS {
+            (walk (fold pending-withdrawals-step PENDING_TICKS {
                 node: start,
                 last-visited: none,
                 rows: (list),

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -114,12 +114,12 @@ export function mineUntil(target: bigint) {
   }
 }
 
-/** Bitcoin blocks after indexing before get-pending-settlements consults sBTC. */
-export const SETTLEMENT_MIN_BURN_AGE = 7n;
+/** Bitcoin blocks after indexing before get-pending-withdrawals consults sBTC. */
+export const WITHDRAWAL_MIN_BURN_AGE = 7n;
 
 /** Mine enough burn blocks for an indexed withdrawal to pass the listing age gate. */
-export function mineUntilSettlementListable() {
-  simnet.mineEmptyBurnBlocks(Number(SETTLEMENT_MIN_BURN_AGE));
+export function mineUntilWithdrawalListable() {
+  simnet.mineEmptyBurnBlocks(Number(WITHDRAWAL_MIN_BURN_AGE));
 }
 
 export function rewardCycleToBurnHeight(cycle: bigint): bigint {
@@ -665,10 +665,10 @@ export function getPendingClaims(cursor: OptionalCV = Cl.none()) {
   ).result;
 }
 
-export function getPendingSettlements(cursor: OptionalCV = Cl.none()) {
+export function getPendingWithdrawals(cursor: OptionalCV = Cl.none()) {
   return simnet.callReadOnlyFn(
     "reward-claim-registry",
-    "get-pending-settlements",
+    "get-pending-withdrawals",
     [cursor],
     deployer,
   ).result;

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -32,7 +32,7 @@ import {
   deployer,
   fundAndCalculateRewards,
   fundAndClaimSignerRewards,
-  getPendingSettlements,
+  getPendingWithdrawals,
   getPendingClaims,
   getEarned,
   getMaliciousLastReenterError,
@@ -41,7 +41,7 @@ import {
   initPox5,
   registerMaliciousSignerManager,
   mineUntilPastDistribution,
-  mineUntilSettlementListable,
+  mineUntilWithdrawalListable,
   processRewardClaim,
   registerForBond,
   registerForClaims,
@@ -139,7 +139,7 @@ function pendingClaimsPage(
   });
 }
 
-function settlementRow(staker: string, requestId: bigint, signerManager = SIGNER_MANAGER) {
+function withdrawalRow(staker: string, requestId: bigint, signerManager = SIGNER_MANAGER) {
   return Cl.tuple({
     staker: Cl.principal(staker),
     "signer-manager": Cl.principal(signerManager),
@@ -147,8 +147,8 @@ function settlementRow(staker: string, requestId: bigint, signerManager = SIGNER
   });
 }
 
-function pendingSettlementsPage(
-  rows: ReturnType<typeof settlementRow>[],
+function pendingWithdrawalsPage(
+  rows: ReturnType<typeof withdrawalRow>[],
   next: ClarityValue = Cl.none(),
 ) {
   return Cl.tuple({
@@ -523,9 +523,9 @@ describe("cancel-registration", () => {
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
 
     acceptWithdrawal(1n, 30n);
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([settlementRow(wallet2, 1n)]),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([withdrawalRow(wallet2, 1n)]),
     );
     expect(
       simnet.callPublicFn(
@@ -535,7 +535,7 @@ describe("cancel-registration", () => {
         wallet3,
       ).result,
     ).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 });
 
@@ -1009,7 +1009,7 @@ describe("bond path", () => {
   });
 });
 
-describe("L1 withdrawal path + settlements", () => {
+describe("L1 withdrawal path + pending withdrawals", () => {
   beforeEach(() => {
     initPox5();
     registerSignerManager(SIGNER_PRIVATE_KEY);
@@ -1024,30 +1024,30 @@ describe("L1 withdrawal path + settlements", () => {
   it("records a withdrawal request-id and lists it once accepted and old enough", () => {
     const { result } = processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(result).toBeOk(Cl.some(Cl.uint(1)));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
 
     acceptWithdrawal(1n, 30n);
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
 
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([settlementRow(wallet1, 1n)]),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([withdrawalRow(wallet1, 1n)]),
     );
   });
 
   it("does not list a still-pending withdrawal even after the age gate", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 
-  it("settles an ACCEPTED withdrawal and clears it from the settlement list", () => {
+  it("settles an ACCEPTED withdrawal and clears it from the pending-withdrawal list", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     acceptWithdrawal(1n, 30n);
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 
   it("settles a REJECTED withdrawal (reclaims to the staker) and clears it", () => {
@@ -1055,15 +1055,15 @@ describe("L1 withdrawal path + settlements", () => {
     rejectWithdrawal(1n);
     const { result } = settlePendingWithdrawal(wallet1, 1n, wallet2);
     expect(result).toBeOk(Cl.bool(true));
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 
   it("is a no-op while the withdrawal is still pending", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeOk(Cl.bool(false));
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 
   it("errors on an unknown pending withdrawal", () => {
@@ -1077,13 +1077,13 @@ describe("L1 withdrawal path + settlements", () => {
     processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
     acceptWithdrawal(1n, 30n);
     expect(settleAcceptedWithdrawalOnSignerManager(1n, wallet2).result).toBeOk(Cl.bool(true));
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([settlementRow(wallet1, 1n)]),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([withdrawalRow(wallet1, 1n)]),
     );
 
     expect(settlePendingWithdrawal(wallet1, 1n, wallet2).result).toBeOk(Cl.bool(true));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 
   it("batch settle-pending-withdrawals resolves accepted items and counts them", () => {
@@ -1102,8 +1102,8 @@ describe("L1 withdrawal path + settlements", () => {
       wallet2,
     );
     expect(result).toBeOk(Cl.uint(1));
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
   });
 
   it("process-reward-claims records withdrawal request-ids", () => {
@@ -1117,14 +1117,14 @@ describe("L1 withdrawal path + settlements", () => {
 
     acceptWithdrawal(1n, 30n);
     acceptWithdrawal(2n, 30n);
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([settlementRow(wallet1, 1n), settlementRow(wallet2, 2n)]),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([withdrawalRow(wallet1, 1n), withdrawalRow(wallet2, 2n)]),
     );
   });
 });
 
-describe("get-pending-settlements pagination", () => {
+describe("get-pending-withdrawals pagination", () => {
   it(
     "paginates past not-yet-settleable withdrawals across >100 ids (Rust get_all style)",
     () => {
@@ -1201,7 +1201,7 @@ describe("get-pending-settlements pagination", () => {
         }
       }
 
-      mineUntilSettlementListable();
+      mineUntilWithdrawalListable();
 
       const expectedIds: bigint[] = [];
       for (let i = 0; i < TOTAL_STAKERS; i++) {
@@ -1220,7 +1220,7 @@ describe("get-pending-settlements pagination", () => {
       let cursor: OptionalCV = Cl.none();
       const pageSizes: number[] = [];
       for (let guard = 0; guard < 10; guard++) {
-        const json = cvToJSON(getPendingSettlements(cursor));
+        const json = cvToJSON(getPendingWithdrawals(cursor));
         expect(json.success).toBe(true);
         const page = json.value.value as {
           rows: {
@@ -1302,9 +1302,9 @@ describe("get-pending-settlements pagination", () => {
       const lastId = BigInt(TOTAL);
       const lastStaker = stakers[TOTAL - 1]!;
       expect(acceptWithdrawal(lastId, 30n).result).toBeOk(Cl.bool(true));
-      mineUntilSettlementListable();
+      mineUntilWithdrawalListable();
 
-      const first = cvToJSON(getPendingSettlements()) as {
+      const first = cvToJSON(getPendingWithdrawals()) as {
         success: boolean;
         value: {
           value: {
@@ -1326,7 +1326,7 @@ describe("get-pending-settlements pagination", () => {
       expect(first.value.value.next.value).not.toBeNull();
 
       const nextKey = first.value.value.next.value!.value;
-      const second = getPendingSettlements(
+      const second = getPendingWithdrawals(
         Cl.some(
           Cl.tuple({
             staker: Cl.principal(nextKey.staker.value),
@@ -1335,7 +1335,7 @@ describe("get-pending-settlements pagination", () => {
           }),
         ),
       );
-      expect(second).toBeOk(pendingSettlementsPage([settlementRow(lastStaker, lastId)]));
+      expect(second).toBeOk(pendingWithdrawalsPage([withdrawalRow(lastStaker, lastId)]));
     },
     300_000,
   );
@@ -1502,7 +1502,7 @@ describe("claim schedule invariants", () => {
       mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
 
       expect(processRewardClaim(wallet1, wallet1, MOCK_SIGNER_MANAGER).result).toBeOk(Cl.none());
-      expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+      expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
       expect(getRegistration(wallet1, MOCK_SIGNER_MANAGER)).toBeSome(
         stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
       );
@@ -1648,9 +1648,9 @@ describe("reentrancy from settle-accepted-withdrawal", () => {
       ).result,
     ).toBeOk(Cl.bool(true));
     expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([settlementRow(wallet2, 1n)]),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([withdrawalRow(wallet2, 1n)]),
     );
   });
 });
@@ -1675,11 +1675,11 @@ describe("withdrawal-request ids that are not a live sBTC pending request", () =
       Cl.some(Cl.uint(1)),
     );
     acceptWithdrawal(1n, 30n);
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([
-        settlementRow(wallet1, 1n),
-        settlementRow(wallet3, 1n, MOCK_SIGNER_MANAGER),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([
+        withdrawalRow(wallet1, 1n),
+        withdrawalRow(wallet3, 1n, MOCK_SIGNER_MANAGER),
       ]),
     );
     expect(getRegistration(wallet3, MOCK_SIGNER_MANAGER)).toBeSome(
@@ -1692,9 +1692,9 @@ describe("withdrawal-request ids that are not a live sBTC pending request", () =
     acceptWithdrawal(1n, 30n);
     setMockClaimStakerResult(false, 1001n, 1000n, Cl.some(Cl.uint(1)));
     expect(processRewardClaim(wallet3, wallet3, MOCK_SIGNER_MANAGER).result).toBeOk(Cl.none());
-    mineUntilSettlementListable();
-    expect(getPendingSettlements()).toBeOk(
-      pendingSettlementsPage([settlementRow(wallet1, 1n)]),
+    mineUntilWithdrawalListable();
+    expect(getPendingWithdrawals()).toBeOk(
+      pendingWithdrawalsPage([withdrawalRow(wallet1, 1n)]),
     );
   });
 });
@@ -1727,7 +1727,7 @@ describe("batch settle SM error does not stick the reentrancy lock", () => {
         wallet2,
       ).result,
     ).toBeOk(Cl.uint(1));
-    expect(getPendingSettlements()).toBeOk(pendingSettlementsPage([]));
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
 
     // Lock was cleared: the SM error was swallowed and the id pruned.
     expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeErr(

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -101,7 +101,7 @@ sbtc_deployer = "SN3R84XZYA63QS28932XQF3G1J8R9PC3W76P9CSQS"
 # !! ===========================================================================
 # !! Reward claims configuration
 # !! ---------------------------------------------------------------------------
-# !! Presence of this stanza enables the reward-claim / settlement process.
+# !! Presence of this stanza enables the reward-claim registry process.
 # !! Requires `[stacks]` as well.
 # !! ===========================================================================
 # [reward_claims]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,7 +64,7 @@ pub struct Settings {
     /// Registry smart contract address
     #[serde(default, deserialize_with = "contract_deserializer_option")]
     pub registry_contract: Option<QualifiedContractIdentifier>,
-    /// Reward-claim / settlement config.
+    /// Reward-claim registry config.
     ///
     /// Presence of this stanza enables the reward-claim process. Requires
     /// [`Settings::stacks`] as well.

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -1,8 +1,8 @@
-//! Tip-driven process that advances reward claims and settlements.
+//! Tip-driven process that advances reward claims and withdrawals.
 //!
 //! On each new Bitcoin chain tip the process:
 //! 1. Fetches pending claims and broadcasts `process-reward-claims` batches,
-//! 2. Fetches pending settlements and broadcasts `settle-pending-withdrawals`
+//! 2. Fetches pending withdrawals and broadcasts `settle-pending-withdrawals`
 //!    batches.
 //!
 //! Run via [`crate::dispatch::run_on_chain_tips`] alongside deposit
@@ -58,8 +58,8 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
             tracing::warn!(%error, "error processing pending reward claims");
         }
 
-        if let Err(error) = process_pending_settlements(&context, &chain_tip).await {
-            tracing::warn!(%error, "error processing pending settlements");
+        if let Err(error) = process_pending_withdrawals(&context, &chain_tip).await {
+            tracing::warn!(%error, "error processing pending withdrawals");
         }
     }
 }
@@ -112,18 +112,18 @@ async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Resul
     Ok(())
 }
 
-/// The function that processes pending settlements.
+/// The function that processes pending withdrawals.
 ///
 /// # Notes
 ///
 /// This function works as follows:
-/// 1. Gets all pending settlements from the registry.
+/// 1. Gets all pending withdrawals from the registry.
 /// 2. Submits a settle-pending-withdrawals contract call for each batch of
-///    settlements, where a batch is a group of at most 100 stakers who are
+///    withdrawals, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
-async fn process_pending_settlements(_: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
-    // TODO(#40/#42): fetch pending settlements and submit settle-pending-withdrawals.
-    tracing::debug!(%chain_tip, "reward settlement processing not yet implemented");
+async fn process_pending_withdrawals(_: &Context, chain_tip: &BlockRef) -> Result<(), Error> {
+    // TODO(#40/#42): fetch pending withdrawals and submit settle-pending-withdrawals.
+    tracing::debug!(%chain_tip, "reward withdrawal processing not yet implemented");
     Ok(())
 }
 

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -22,7 +22,7 @@ use crate::stacks::node::StacksClient;
 /// Maximum list length for registry batch contract calls.
 ///
 /// Used by both `process-reward-claims` (stakers) and
-/// `settle-pending-withdrawals` (settlement items).
+/// `settle-pending-withdrawals` (withdrawal items).
 pub const MAX_STAKERS_LENGTH: usize = 100;
 
 /// Type signature for list elements of settle-pending-withdrawals items.
@@ -31,7 +31,7 @@ pub const MAX_STAKERS_LENGTH: usize = 100;
 /// depth exceeds 32, or the max would-be size exceeds 1 MiB. Ours are
 /// non-empty with a max depth less than 3, and a max would-be size less
 /// than 500 bytes. We also exercised this code in the contract-call tests.
-pub static TUPLE_SETTLEMENT_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
+pub static TUPLE_WITHDRAWAL_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
     TupleTypeSignature::try_from(BTreeMap::from([
         (ClarityName::from("staker"), TypeSignature::PrincipalType),
         (ClarityName::from("request-id"), TypeSignature::UIntType),
@@ -39,11 +39,11 @@ pub static TUPLE_SETTLEMENT_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyL
     .unwrap()
 });
 
-/// Type signature for settlement cursors.
+/// Type signature for withdrawal cursors.
 ///
 /// This `TupleTypeSignature::try_from` has the same caveats mentioned in
-/// the docstring for [`TUPLE_SETTLEMENT_ITEM_SIGNATURE`].
-static TUPLE_SETTLEMENT_KEY_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
+/// the docstring for [`TUPLE_WITHDRAWAL_ITEM_SIGNATURE`].
+static TUPLE_WITHDRAWAL_KEY_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
     TupleTypeSignature::try_from(BTreeMap::from([
         (ClarityName::from("staker"), TypeSignature::PrincipalType),
         (
@@ -102,10 +102,10 @@ pub struct PendingClaimsPage {
 
 /// Key identifying a pending withdrawal in the reward claim registry.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SettlementKey(TupleData);
+pub struct WithdrawalKey(TupleData);
 
-impl SettlementKey {
-    /// Build a settlement cursor tuple from its fields.
+impl WithdrawalKey {
+    /// Build a withdrawal cursor tuple from its fields.
     pub fn new(staker: PrincipalData, signer_manager: PrincipalData, request_id: u128) -> Self {
         let data_map = BTreeMap::from([
             (ClarityName::from("staker"), ClarityValue::Principal(staker)),
@@ -118,7 +118,7 @@ impl SettlementKey {
                 ClarityValue::UInt(request_id),
             ),
         ]);
-        let type_signature = TUPLE_SETTLEMENT_KEY_SIGNATURE.clone();
+        let type_signature = TUPLE_WITHDRAWAL_KEY_SIGNATURE.clone();
         Self(TupleData { type_signature, data_map })
     }
 
@@ -131,10 +131,10 @@ impl SettlementKey {
 /// This type holds a list element for the items argument for a
 /// `settle-pending-withdrawals` contract call.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SettlementItem(TupleData);
+pub struct WithdrawalItem(TupleData);
 
-impl SettlementItem {
-    /// Build a settlement item from its fields.
+impl WithdrawalItem {
+    /// Build a withdrawal item from its fields.
     pub fn new(staker: PrincipalData, request_id: u128) -> Self {
         let data_map = BTreeMap::from([
             (ClarityName::from("staker"), ClarityValue::Principal(staker)),
@@ -143,7 +143,7 @@ impl SettlementItem {
                 ClarityValue::UInt(request_id),
             ),
         ]);
-        let type_signature = TUPLE_SETTLEMENT_ITEM_SIGNATURE.clone();
+        let type_signature = TUPLE_WITHDRAWAL_ITEM_SIGNATURE.clone();
         Self(TupleData { type_signature, data_map })
     }
 
@@ -156,7 +156,7 @@ impl SettlementItem {
     pub fn staker(&self) -> &PrincipalData {
         match self.0.get("staker") {
             Ok(ClarityValue::Principal(staker)) => staker,
-            _ => unreachable!("settlement item always has a principal staker"),
+            _ => unreachable!("withdrawal item always has a principal staker"),
         }
     }
 
@@ -164,40 +164,40 @@ impl SettlementItem {
     pub fn request_id(&self) -> u128 {
         match self.0.get("request-id") {
             Ok(ClarityValue::UInt(request_id)) => *request_id,
-            _ => unreachable!("settlement item always has a uint request-id"),
+            _ => unreachable!("withdrawal item always has a uint request-id"),
         }
     }
 }
 
-/// A single pending settlement row from `get-pending-settlements`.
+/// A single pending withdrawal row from `get-pending-withdrawals`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PendingSettlement {
+pub struct PendingWithdrawal {
     /// The signer-manager principal for this pending withdrawal.
     pub signer_manager: QualifiedContractIdentifier,
     /// Prebuilt `{staker, request-id}` for `settle-pending-withdrawals`.
-    pub item: SettlementItem,
+    pub item: WithdrawalItem,
 }
 
-impl PendingSettlement {
-    /// Settlement key for this row (for tests / cursors derived from a row).
-    pub fn settlement_key(&self) -> SettlementKey {
+impl PendingWithdrawal {
+    /// Withdrawal key for this row (for tests / cursors derived from a row).
+    pub fn withdrawal_key(&self) -> WithdrawalKey {
         let staker = self.item.staker().clone();
         let signer_manager = PrincipalData::Contract(self.signer_manager.clone());
-        SettlementKey::new(staker, signer_manager, self.item.request_id())
+        WithdrawalKey::new(staker, signer_manager, self.item.request_id())
     }
 }
 
-/// One page from `get-pending-settlements`.
+/// One page from `get-pending-withdrawals`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PendingSettlementsPage {
-    /// Pending settlement rows found during this bounded walk.
-    pub settlements: Vec<PendingSettlement>,
-    /// Cursor to pass to the next `get_pending_settlements` call.
+pub struct PendingWithdrawalsPage {
+    /// Pending withdrawal rows found during this bounded walk.
+    pub withdrawals: Vec<PendingWithdrawal>,
+    /// Cursor to pass to the next `get_pending_withdrawals` call.
     ///
     /// `None` means the walk reached the tail of the pending-withdrawal
-    /// list. `Some` is the last visited settlement key, which may not be
+    /// list. `Some` is the last visited withdrawal key, which may not be
     /// a settleable row itself.
-    pub next: Option<SettlementKey>,
+    pub next: Option<WithdrawalKey>,
 }
 
 /// Arguments for one `process-reward-claims` contract call.
@@ -251,22 +251,22 @@ impl RewardClaimsBatch {
 /// All [`Self::items`] share [`Self::signer_manager`], and the list length
 /// is at most [`MAX_STAKERS_LENGTH`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SettlementsBatch {
+pub struct WithdrawalsBatch {
     /// Signer-manager trait principal passed to `settle-pending-withdrawals`.
     signer_manager: QualifiedContractIdentifier,
-    /// Settlement items to settle in this call (1..=100).
-    items: Vec<SettlementItem>,
+    /// Withdrawal items to settle in this call (1..=100).
+    items: Vec<WithdrawalItem>,
     /// The address that deployed the rewards claim registry.
     deployer: StacksAddress,
 }
 
-impl SettlementsBatch {
-    /// Create a new dummy settlements batch.
+impl WithdrawalsBatch {
+    /// Create a new dummy withdrawals batch.
     #[cfg(test)]
     pub fn dummy() -> Self {
         Self {
             signer_manager: QualifiedContractIdentifier::transient(),
-            items: vec![SettlementItem::new(
+            items: vec![WithdrawalItem::new(
                 PrincipalData::from(StacksAddress::burn_address(false)),
                 1,
             )],
@@ -279,8 +279,8 @@ impl SettlementsBatch {
         &self.signer_manager
     }
 
-    /// The settlement items to settle in this call.
-    pub fn into_items(self) -> std::vec::IntoIter<SettlementItem> {
+    /// The withdrawal items to settle in this call.
+    pub fn into_items(self) -> std::vec::IntoIter<WithdrawalItem> {
         self.items.into_iter()
     }
 
@@ -396,18 +396,18 @@ impl RewardClaimRegistry {
         Ok(batch_claims(claims, &self.deployer))
     }
 
-    /// Fetch a page of pending settlements from the registry.
+    /// Fetch a page of pending withdrawals from the registry.
     ///
     /// Pass `None` for `cursor` to start at the head of the pending-
     /// withdrawal linked list. To paginate, pass
-    /// [`PendingSettlementsPage::next`] from the previous page.
+    /// [`PendingWithdrawalsPage::next`] from the previous page.
     /// `next == None` means the walk reached the tail; an empty
-    /// `settlements` list alone does not.
-    async fn get_pending_settlements(
+    /// `withdrawals` list alone does not.
+    async fn get_pending_withdrawals(
         &self,
-        cursor: Option<SettlementKey>,
+        cursor: Option<WithdrawalKey>,
         chain_tip: Option<&StacksBlockId>,
-    ) -> Result<PendingSettlementsPage, Error> {
+    ) -> Result<PendingWithdrawalsPage, Error> {
         let cursor_arg = match cursor {
             Some(key) => ClarityValue::some(ClarityValue::Tuple(key.into_tuple()))
                 .map_err(|error| Error::ClarityTuple(Box::new(error)))?,
@@ -419,7 +419,7 @@ impl RewardClaimRegistry {
             .call_read(
                 &self.deployer,
                 &self.contract_name,
-                &ClarityName::from("get-pending-settlements"),
+                &ClarityName::from("get-pending-withdrawals"),
                 &self.deployer,
                 &[cursor_arg],
                 chain_tip,
@@ -430,23 +430,23 @@ impl RewardClaimRegistry {
             return Err(Error::InvalidStacksResponse("expected a response"));
         };
 
-        PendingSettlementsPage::try_from(*response.data)
+        PendingWithdrawalsPage::try_from(*response.data)
     }
 
-    /// Fetch every pending settlement by paging through
-    /// `get-pending-settlements`.
+    /// Fetch every pending withdrawal by paging through
+    /// `get-pending-withdrawals`.
     ///
     /// Continues while the page's `next` cursor is `Some`.
-    async fn get_all_pending_settlements(&self) -> Result<Vec<PendingSettlement>, Error> {
+    async fn get_all_pending_withdrawals(&self) -> Result<Vec<PendingWithdrawal>, Error> {
         let mut all = Vec::new();
-        let mut cursor: Option<SettlementKey> = None;
+        let mut cursor: Option<WithdrawalKey> = None;
 
         let tip = self.client.get_node_info().await?.chain_tip();
         let chain_tip = Some(&tip);
 
         loop {
-            let page = self.get_pending_settlements(cursor, chain_tip).await?;
-            all.extend(page.settlements);
+            let page = self.get_pending_withdrawals(cursor, chain_tip).await?;
+            all.extend(page.withdrawals);
             match page.next {
                 Some(next) => cursor = Some(next),
                 None => break,
@@ -456,11 +456,11 @@ impl RewardClaimRegistry {
         Ok(all)
     }
 
-    /// Get all pending settlements, batched by signer manager, with chunks
+    /// Get all pending withdrawals, batched by signer manager, with chunks
     /// of at most [`MAX_STAKERS_LENGTH`] items per batch.
-    pub async fn get_pending_settlement_batches(&self) -> Result<Vec<SettlementsBatch>, Error> {
-        let settlements = self.get_all_pending_settlements().await?;
-        Ok(batch_settlements(settlements, &self.deployer))
+    pub async fn get_pending_withdrawal_batches(&self) -> Result<Vec<WithdrawalsBatch>, Error> {
+        let withdrawals = self.get_all_pending_withdrawals().await?;
+        Ok(batch_withdrawals(withdrawals, &self.deployer))
     }
 }
 
@@ -491,27 +491,27 @@ fn batch_claims(claims: Vec<PendingClaim>, deployer: &StacksAddress) -> Vec<Rewa
     batches
 }
 
-/// Group pending settlements by signer-manager and split into contract-call
+/// Group pending withdrawals by signer-manager and split into contract-call
 /// batches.
 ///
 /// Each batch has at most [`MAX_STAKERS_LENGTH`] items.
-fn batch_settlements(
-    settlements: Vec<PendingSettlement>,
+fn batch_withdrawals(
+    withdrawals: Vec<PendingWithdrawal>,
     deployer: &StacksAddress,
-) -> Vec<SettlementsBatch> {
-    let mut groups: HashMap<QualifiedContractIdentifier, Vec<SettlementItem>> = HashMap::new();
+) -> Vec<WithdrawalsBatch> {
+    let mut groups: HashMap<QualifiedContractIdentifier, Vec<WithdrawalItem>> = HashMap::new();
 
-    for settlement in settlements {
+    for withdrawal in withdrawals {
         groups
-            .entry(settlement.signer_manager)
+            .entry(withdrawal.signer_manager)
             .or_default()
-            .push(settlement.item);
+            .push(withdrawal.item);
     }
 
     let mut batches = Vec::new();
     for (signer_manager, items) in groups {
         for chunk in items.chunks(MAX_STAKERS_LENGTH) {
-            batches.push(SettlementsBatch {
+            batches.push(WithdrawalsBatch {
                 signer_manager: signer_manager.clone(),
                 items: chunk.to_vec(),
                 deployer: deployer.clone(),
@@ -586,7 +586,7 @@ impl TryFrom<ClarityValue> for PendingClaimsPage {
     }
 }
 
-impl TryFrom<ClarityValue> for SettlementKey {
+impl TryFrom<ClarityValue> for WithdrawalKey {
     type Error = Error;
 
     fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
@@ -596,11 +596,11 @@ impl TryFrom<ClarityValue> for SettlementKey {
         let signer_manager = clarity_map.remove_principal("signer-manager")?;
         let request_id = clarity_map.remove_uint("request-id")?;
 
-        Ok(SettlementKey::new(staker, signer_manager, request_id))
+        Ok(WithdrawalKey::new(staker, signer_manager, request_id))
     }
 }
 
-impl TryFrom<ClarityValue> for PendingSettlement {
+impl TryFrom<ClarityValue> for PendingWithdrawal {
     type Error = Error;
 
     fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
@@ -617,31 +617,31 @@ impl TryFrom<ClarityValue> for PendingSettlement {
         let staker = clarity_map.remove_principal("staker")?;
         let request_id = clarity_map.remove_uint("request-id")?;
 
-        Ok(PendingSettlement {
+        Ok(PendingWithdrawal {
             signer_manager,
-            item: SettlementItem::new(staker, request_id),
+            item: WithdrawalItem::new(staker, request_id),
         })
     }
 }
 
-impl TryFrom<ClarityValue> for PendingSettlementsPage {
+impl TryFrom<ClarityValue> for PendingWithdrawalsPage {
     type Error = Error;
 
     fn try_from(value: ClarityValue) -> Result<Self, Self::Error> {
         let mut clarity_map = ClarityTuple::try_from(value)?;
 
-        let settlements = clarity_map
+        let withdrawals = clarity_map
             .remove_list("rows")?
             .into_iter()
-            .map(PendingSettlement::try_from)
+            .map(PendingWithdrawal::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
         let next = clarity_map
             .remove_option("next")?
-            .map(SettlementKey::try_from)
+            .map(WithdrawalKey::try_from)
             .transpose()?;
 
-        Ok(PendingSettlementsPage { settlements, next })
+        Ok(PendingWithdrawalsPage { withdrawals, next })
     }
 }
 
@@ -697,8 +697,8 @@ mod tests {
         }
     }
 
-    impl From<&PendingSettlement> for ClarityValue {
-        fn from(value: &PendingSettlement) -> Self {
+    impl From<&PendingWithdrawal> for ClarityValue {
+        fn from(value: &PendingWithdrawal) -> Self {
             let tuple_entries = vec![
                 (
                     ClarityName::from("signer-manager"),
@@ -717,8 +717,8 @@ mod tests {
         }
     }
 
-    impl From<&SettlementKey> for ClarityValue {
-        fn from(value: &SettlementKey) -> Self {
+    impl From<&WithdrawalKey> for ClarityValue {
+        fn from(value: &WithdrawalKey) -> Self {
             ClarityValue::Tuple(value.clone().into_tuple())
         }
     }
@@ -742,11 +742,11 @@ mod tests {
         ClarityValue::okay(page).unwrap()
     }
 
-    fn ok_settlements_page(
-        settlements: &[PendingSettlement],
-        next: Option<&SettlementKey>,
+    fn ok_withdrawals_page(
+        withdrawals: &[PendingWithdrawal],
+        next: Option<&WithdrawalKey>,
     ) -> ClarityValue {
-        let rows: Vec<ClarityValue> = settlements.iter().map(ClarityValue::from).collect();
+        let rows: Vec<ClarityValue> = withdrawals.iter().map(ClarityValue::from).collect();
         let next_value = match next {
             Some(key) => ClarityValue::some(ClarityValue::from(key)).unwrap(),
             None => ClarityValue::none(),
@@ -1124,24 +1124,24 @@ mod tests {
         );
     }
 
-    fn settlement(
+    fn withdrawal(
         signer_manager: &QualifiedContractIdentifier,
         staker: PrincipalData,
         request_id: u128,
-    ) -> PendingSettlement {
-        PendingSettlement {
+    ) -> PendingWithdrawal {
+        PendingWithdrawal {
             signer_manager: signer_manager.clone(),
-            item: SettlementItem::new(staker, request_id),
+            item: WithdrawalItem::new(staker, request_id),
         }
     }
 
     #[test]
-    fn batch_pending_settlements_empty() {
-        assert!(batch_settlements(vec![], &StacksAddress::burn_address(false)).is_empty());
+    fn batch_pending_withdrawals_empty() {
+        assert!(batch_withdrawals(vec![], &StacksAddress::burn_address(false)).is_empty());
     }
 
     #[test]
-    fn batch_pending_settlements_groups_by_signer_manager() {
+    fn batch_pending_withdrawals_groups_by_signer_manager() {
         let sm_a = QualifiedContractIdentifier::parse(
             "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
         )
@@ -1155,13 +1155,13 @@ mod tests {
         let staker3 =
             PrincipalData::parse("ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.staker-3").unwrap();
 
-        let settlements = vec![
-            settlement(&sm_a, staker1.clone(), 1),
-            settlement(&sm_b, staker2.clone(), 2),
-            settlement(&sm_a, staker3.clone(), 3),
+        let withdrawals = vec![
+            withdrawal(&sm_a, staker1.clone(), 1),
+            withdrawal(&sm_b, staker2.clone(), 2),
+            withdrawal(&sm_a, staker3.clone(), 3),
         ];
 
-        let batches = batch_settlements(settlements, &StacksAddress::burn_address(false));
+        let batches = batch_withdrawals(withdrawals, &StacksAddress::burn_address(false));
         assert_eq!(batches.len(), 2);
 
         let batch_a = batches
@@ -1177,25 +1177,25 @@ mod tests {
         assert_eq!(
             batch_a_items,
             vec![
-                SettlementItem::new(staker1, 1),
-                SettlementItem::new(staker3, 3)
+                WithdrawalItem::new(staker1, 1),
+                WithdrawalItem::new(staker3, 3)
             ]
         );
         assert_eq!(batch_a.deployer(), &StacksAddress::burn_address(false));
         assert_eq!(batch_b.deployer(), &StacksAddress::burn_address(false));
         let batch_b_items: Vec<_> = batch_b.clone().into_items().collect();
-        assert_eq!(batch_b_items, vec![SettlementItem::new(staker2, 2)]);
+        assert_eq!(batch_b_items, vec![WithdrawalItem::new(staker2, 2)]);
     }
 
     #[test]
-    fn batch_pending_settlements_chunks_at_max_items() {
+    fn batch_pending_withdrawals_chunks_at_max_items() {
         let sm = QualifiedContractIdentifier::parse(
             "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
         )
         .unwrap();
-        let settlements: Vec<_> = (0..=MAX_STAKERS_LENGTH)
+        let withdrawals: Vec<_> = (0..=MAX_STAKERS_LENGTH)
             .map(|i| {
-                settlement(
+                withdrawal(
                     &sm,
                     PrincipalData::parse(&format!(
                         "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.s{i}"
@@ -1206,7 +1206,7 @@ mod tests {
             })
             .collect();
 
-        let batches = batch_settlements(settlements.clone(), &StacksAddress::burn_address(false));
+        let batches = batch_withdrawals(withdrawals.clone(), &StacksAddress::burn_address(false));
         assert_eq!(batches.len(), 2);
         assert!(batches.iter().all(|batch| batch.signer_manager() == &sm));
 
@@ -1214,36 +1214,36 @@ mod tests {
         let batch1_items: Vec<_> = batches[1].clone().into_items().collect();
         assert_eq!(batch0_items.len(), MAX_STAKERS_LENGTH);
         assert_eq!(batch1_items.len(), 1);
-        assert_eq!(batch0_items[0], settlements[0].item);
+        assert_eq!(batch0_items[0], withdrawals[0].item);
         assert_eq!(
             batch0_items[MAX_STAKERS_LENGTH - 1],
-            settlements[MAX_STAKERS_LENGTH - 1].item
+            withdrawals[MAX_STAKERS_LENGTH - 1].item
         );
-        assert_eq!(batch1_items[0], settlements[MAX_STAKERS_LENGTH].item);
+        assert_eq!(batch1_items[0], withdrawals[MAX_STAKERS_LENGTH].item);
     }
 
     #[tokio::test]
-    async fn get_pending_settlements_works_without_cursor() {
+    async fn get_pending_withdrawals_works_without_cursor() {
         let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
         let signer_manager = QualifiedContractIdentifier::parse(
             "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
         )
         .unwrap();
 
-        let settlement = PendingSettlement {
+        let withdrawal = PendingWithdrawal {
             signer_manager,
-            item: SettlementItem::new(staker, 7),
+            item: WithdrawalItem::new(staker, 7),
         };
-        let next = settlement.settlement_key();
+        let next = withdrawal.withdrawal_key();
 
         let raw_json_response = format!(
             r#"{{"okay": true, "result":"0x{}"}}"#,
-            ok_settlements_page(&[settlement.clone()], Some(&next))
+            ok_withdrawals_page(&[withdrawal.clone()], Some(&next))
                 .serialize_to_hex()
                 .unwrap(),
         );
 
-        let path = "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-settlements?tip=latest";
+        let path = "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest";
         let mut stacks_node_server = mockito::Server::new_async().await;
         let mock = stacks_node_server
             .mock("POST", path)
@@ -1267,9 +1267,9 @@ mod tests {
             client,
         );
 
-        let result = registry.get_pending_settlements(None, None).await.unwrap();
-        let expected = PendingSettlementsPage {
-            settlements: vec![settlement],
+        let result = registry.get_pending_withdrawals(None, None).await.unwrap();
+        let expected = PendingWithdrawalsPage {
+            withdrawals: vec![withdrawal],
             next: Some(next),
         };
         assert_eq!(result, expected);
@@ -1277,19 +1277,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_pending_settlements_works_with_cursor() {
+    async fn get_pending_withdrawals_works_with_cursor() {
         let staker = PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap();
         let signer_manager = QualifiedContractIdentifier::parse(
             "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
         )
         .unwrap();
 
-        let cursor = SettlementKey::new(staker, PrincipalData::Contract(signer_manager.clone()), 1);
+        let cursor = WithdrawalKey::new(staker, PrincipalData::Contract(signer_manager.clone()), 1);
 
         let staker2 = PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap();
-        let settlement = PendingSettlement {
+        let withdrawal = PendingWithdrawal {
             signer_manager,
-            item: SettlementItem::new(staker2, 99),
+            item: WithdrawalItem::new(staker2, 99),
         };
 
         let cursor_hex = ClarityValue::some(ClarityValue::from(&cursor))
@@ -1299,7 +1299,7 @@ mod tests {
 
         let raw_json_response = format!(
             r#"{{"okay": true, "result":"0x{}"}}"#,
-            ok_settlements_page(&[settlement.clone()], None)
+            ok_withdrawals_page(&[withdrawal.clone()], None)
                 .serialize_to_hex()
                 .unwrap(),
         );
@@ -1308,7 +1308,7 @@ mod tests {
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-settlements?tip=latest",
+                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest",
             )
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [cursor_hex]
@@ -1331,12 +1331,12 @@ mod tests {
         );
 
         let result = registry
-            .get_pending_settlements(Some(cursor), None)
+            .get_pending_withdrawals(Some(cursor), None)
             .await
             .unwrap();
 
-        let expected = PendingSettlementsPage {
-            settlements: vec![settlement],
+        let expected = PendingWithdrawalsPage {
+            withdrawals: vec![withdrawal],
             next: None,
         };
         assert_eq!(result, expected);
@@ -1344,17 +1344,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_pending_settlements_empty_page_at_tail() {
+    async fn get_pending_withdrawals_empty_page_at_tail() {
         let raw_json_response = format!(
             r#"{{"okay": true, "result":"0x{}"}}"#,
-            ok_settlements_page(&[], None).serialize_to_hex().unwrap(),
+            ok_withdrawals_page(&[], None).serialize_to_hex().unwrap(),
         );
 
         let mut stacks_node_server = mockito::Server::new_async().await;
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-settlements?tip=latest",
+                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest",
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1373,10 +1373,10 @@ mod tests {
             client,
         );
 
-        let result = registry.get_pending_settlements(None, None).await.unwrap();
+        let result = registry.get_pending_withdrawals(None, None).await.unwrap();
 
-        let expected = PendingSettlementsPage {
-            settlements: vec![],
+        let expected = PendingWithdrawalsPage {
+            withdrawals: vec![],
             next: None,
         };
         assert_eq!(result, expected);
@@ -1384,21 +1384,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_all_pending_settlements_continues_on_empty_rows_with_next() {
+    async fn get_all_pending_withdrawals_continues_on_empty_rows_with_next() {
         let signer_manager = QualifiedContractIdentifier::parse(
             "ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039.signer-manager",
         )
         .unwrap();
 
         // First page: ticks burned on non-settleable nodes, resume cursor only.
-        let skipped = SettlementKey::new(
+        let skipped = WithdrawalKey::new(
             PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap(),
             PrincipalData::Contract(signer_manager.clone()),
             3,
         );
-        let pending = PendingSettlement {
+        let pending = PendingWithdrawal {
             signer_manager: signer_manager.clone(),
-            item: SettlementItem::new(
+            item: WithdrawalItem::new(
                 PrincipalData::parse("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap(),
                 99,
             ),
@@ -1432,7 +1432,7 @@ mod tests {
             .create();
 
         let path = format!(
-            "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-settlements?tip={tip}"
+            "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip={tip}"
         );
 
         let empty_with_next = stacks_node_server
@@ -1444,7 +1444,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(format!(
                 r#"{{"okay": true, "result":"0x{}"}}"#,
-                ok_settlements_page(&[], Some(&skipped))
+                ok_withdrawals_page(&[], Some(&skipped))
                     .serialize_to_hex()
                     .unwrap(),
             ))
@@ -1460,7 +1460,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .with_body(format!(
                 r#"{{"okay": true, "result":"0x{}"}}"#,
-                ok_settlements_page(&[pending.clone()], None)
+                ok_withdrawals_page(&[pending.clone()], None)
                     .serialize_to_hex()
                     .unwrap(),
             ))
@@ -1478,7 +1478,7 @@ mod tests {
             client,
         );
 
-        let result = registry.get_all_pending_settlements().await.unwrap();
+        let result = registry.get_all_pending_withdrawals().await.unwrap();
 
         assert_eq!(result, vec![pending]);
         info_mock.assert();

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -9,8 +9,12 @@ use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::ClarityName;
 use clarity::vm::ContractName;
 use clarity::vm::Value as ClarityValue;
+use clarity::vm::types::CallableData;
+use clarity::vm::types::ListData;
+use clarity::vm::types::ListTypeData;
 use clarity::vm::types::PrincipalData;
 use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::types::SequenceData;
 use clarity::vm::types::TupleData;
 use clarity::vm::types::TupleTypeSignature;
 use clarity::vm::types::TypeSignature;
@@ -18,6 +22,8 @@ use clarity::vm::types::TypeSignature;
 use crate::error::Error;
 use crate::stacks::clarity::ClarityTuple;
 use crate::stacks::node::StacksClient;
+use crate::stacks::transaction::IntoContractCall;
+use crate::stacks::transaction::make_trait_identifier;
 
 /// Maximum list length for registry batch contract calls.
 ///
@@ -31,7 +37,7 @@ pub const MAX_STAKERS_LENGTH: usize = 100;
 /// depth exceeds 32, or the max would-be size exceeds 1 MiB. Ours are
 /// non-empty with a max depth less than 3, and a max would-be size less
 /// than 500 bytes. We also exercised this code in the contract-call tests.
-pub static TUPLE_WITHDRAWAL_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
+static TUPLE_WITHDRAWAL_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
     TupleTypeSignature::try_from(BTreeMap::from([
         (ClarityName::from("staker"), TypeSignature::PrincipalType),
         (ClarityName::from("request-id"), TypeSignature::UIntType),
@@ -53,6 +59,27 @@ static TUPLE_WITHDRAWAL_KEY_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::
         (ClarityName::from("request-id"), TypeSignature::UIntType),
     ]))
     .unwrap()
+});
+
+/// The type signature for the list of 100 stakers.
+///
+/// ListTypeData::new_list only returns an Err when max size of the type
+/// could be greater than 1 MiB, or if the type depth is greater than 32.
+/// Our type depth is 1 and the max size is 148 * 100 + 6 bytes, well under
+/// 1 MiB. We also have a test that exercises this path so we know that
+/// this won't panic in production.
+static LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
+    ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH as u32).unwrap()
+});
+
+/// The type signature for the list of 100 `{staker, request-id}` items.
+///
+/// Same size bounds as [`LIST_PRINCIPALS_SIGNATURE`]: depth is small and the
+/// max serialized size is well under 1 MiB. Exercised by the dummy
+/// `WithdrawalsBatch` contract-call test.
+static LIST_WITHDRAWAL_ITEMS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
+    let entry_type = TUPLE_WITHDRAWAL_ITEM_SIGNATURE.clone().into();
+    ListTypeData::new_list(entry_type, MAX_STAKERS_LENGTH as u32).unwrap()
 });
 
 /// Key identifying a registration in the reward claim registry.
@@ -234,15 +261,33 @@ impl RewardClaimsBatch {
     pub fn num_stakers(&self) -> usize {
         self.stakers.len()
     }
+}
 
-    /// The stakers to claim for in this call.
-    pub fn stakers(self) -> Vec<PrincipalData> {
-        self.stakers
-    }
-
-    /// The address that deployed the rewards claim registry.
-    pub fn deployer(&self) -> &StacksAddress {
+impl IntoContractCall for RewardClaimsBatch {
+    /// The name of the clarity smart contract that relates to this struct.
+    const CONTRACT_NAME: &'static str = "reward-claim-registry";
+    /// The specific function name that relates to this struct.
+    const FUNCTION_NAME: &'static str = "process-reward-claims";
+    /// The stacks address that deployed the contract.
+    fn deployer_address(&self) -> &StacksAddress {
         &self.deployer
+    }
+    /// The arguments to the clarity function.
+    fn into_contract_args(self) -> Vec<ClarityValue> {
+        let callable = CallableData {
+            contract_identifier: self.signer_manager,
+            trait_identifier: Some(make_trait_identifier(self.deployer)),
+        };
+        let stakers = self.stakers.into_iter().map(ClarityValue::Principal);
+        let stakers = ListData {
+            data: stakers.collect(),
+            type_signature: LIST_PRINCIPALS_SIGNATURE.clone(),
+        };
+
+        vec![
+            ClarityValue::CallableContract(callable),
+            ClarityValue::Sequence(SequenceData::List(stakers)),
+        ]
     }
 }
 
@@ -264,12 +309,10 @@ impl WithdrawalsBatch {
     /// Create a new dummy withdrawals batch.
     #[cfg(test)]
     pub fn dummy() -> Self {
+        let principal = PrincipalData::from(StacksAddress::burn_address(false));
         Self {
             signer_manager: QualifiedContractIdentifier::transient(),
-            items: vec![WithdrawalItem::new(
-                PrincipalData::from(StacksAddress::burn_address(false)),
-                1,
-            )],
+            items: vec![WithdrawalItem::new(principal, 1)],
             deployer: StacksAddress::burn_address(false),
         }
     }
@@ -278,15 +321,35 @@ impl WithdrawalsBatch {
     pub fn signer_manager(&self) -> &QualifiedContractIdentifier {
         &self.signer_manager
     }
+}
 
-    /// The withdrawal items to settle in this call.
-    pub fn into_items(self) -> std::vec::IntoIter<WithdrawalItem> {
-        self.items.into_iter()
-    }
-
-    /// The address that deployed the rewards claim registry.
-    pub fn deployer(&self) -> &StacksAddress {
+impl IntoContractCall for WithdrawalsBatch {
+    /// The name of the clarity smart contract that relates to this struct.
+    const CONTRACT_NAME: &'static str = "reward-claim-registry";
+    /// The specific function name that relates to this struct.
+    const FUNCTION_NAME: &'static str = "settle-pending-withdrawals";
+    /// The stacks address that deployed the contract.
+    fn deployer_address(&self) -> &StacksAddress {
         &self.deployer
+    }
+    /// The arguments to the clarity function.
+    fn into_contract_args(self) -> Vec<ClarityValue> {
+        let callable = CallableData {
+            contract_identifier: self.signer_manager,
+            trait_identifier: Some(make_trait_identifier(self.deployer)),
+        };
+        let data = self
+            .items
+            .into_iter()
+            .map(|item| ClarityValue::Tuple(item.into_tuple()))
+            .collect::<Vec<_>>();
+
+        let type_signature = LIST_WITHDRAWAL_ITEMS_SIGNATURE.clone();
+
+        vec![
+            ClarityValue::CallableContract(callable),
+            ClarityValue::Sequence(SequenceData::List(ListData { data, type_signature })),
+        ]
     }
 }
 
@@ -1082,10 +1145,8 @@ mod tests {
             .find(|batch| batch.signer_manager() == &sm_b)
             .expect("batch for signer-manager B");
 
-        assert_eq!(batch_a.deployer(), &StacksAddress::burn_address(false));
-        assert_eq!(batch_b.deployer(), &StacksAddress::burn_address(false));
-        assert_eq!(batch_a.clone().stakers(), vec![staker1, staker3]);
-        assert_eq!(batch_b.clone().stakers(), vec![staker2]);
+        assert_eq!(batch_a.stakers, vec![staker1, staker3]);
+        assert_eq!(batch_b.stakers, vec![staker2]);
     }
 
     #[test]
@@ -1112,16 +1173,13 @@ mod tests {
         assert!(batches.iter().all(|batch| batch.signer_manager() == &sm));
         assert_eq!(batches[0].num_stakers(), MAX_STAKERS_LENGTH);
         assert_eq!(batches[1].num_stakers(), 1);
-        let batch0_stakers = batches[0].clone().stakers();
+        let batch0_stakers = batches[0].stakers.clone();
         assert_eq!(batch0_stakers[0], claims[0].staker);
         assert_eq!(
             batch0_stakers[MAX_STAKERS_LENGTH - 1],
             claims[MAX_STAKERS_LENGTH - 1].staker
         );
-        assert_eq!(
-            batches[1].clone().stakers()[0],
-            claims[MAX_STAKERS_LENGTH].staker
-        );
+        assert_eq!(batches[1].stakers[0], claims[MAX_STAKERS_LENGTH].staker);
     }
 
     fn withdrawal(
@@ -1173,7 +1231,7 @@ mod tests {
             .find(|batch| batch.signer_manager() == &sm_b)
             .expect("batch for signer-manager B");
 
-        let batch_a_items: Vec<_> = batch_a.clone().into_items().collect();
+        let batch_a_items: Vec<_> = batch_a.items.clone();
         assert_eq!(
             batch_a_items,
             vec![
@@ -1181,9 +1239,7 @@ mod tests {
                 WithdrawalItem::new(staker3, 3)
             ]
         );
-        assert_eq!(batch_a.deployer(), &StacksAddress::burn_address(false));
-        assert_eq!(batch_b.deployer(), &StacksAddress::burn_address(false));
-        let batch_b_items: Vec<_> = batch_b.clone().into_items().collect();
+        let batch_b_items: Vec<_> = batch_b.items.clone();
         assert_eq!(batch_b_items, vec![WithdrawalItem::new(staker2, 2)]);
     }
 
@@ -1210,8 +1266,8 @@ mod tests {
         assert_eq!(batches.len(), 2);
         assert!(batches.iter().all(|batch| batch.signer_manager() == &sm));
 
-        let batch0_items: Vec<_> = batches[0].clone().into_items().collect();
-        let batch1_items: Vec<_> = batches[1].clone().into_items().collect();
+        let batch0_items: Vec<_> = batches[0].items.clone();
+        let batch1_items: Vec<_> = batches[1].items.clone();
         assert_eq!(batch0_items.len(), MAX_STAKERS_LENGTH);
         assert_eq!(batch1_items.len(), 1);
         assert_eq!(batch0_items[0], withdrawals[0].item);

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -1,8 +1,6 @@
 //!  For constructing Stacks transactions that interact with the
 //!  reward-claim registry.
 
-use std::sync::LazyLock;
-
 use blockstack_lib::chainstate::stacks::TransactionContractCall;
 use blockstack_lib::chainstate::stacks::TransactionPayload;
 use blockstack_lib::chainstate::stacks::TransactionPostCondition;
@@ -10,41 +8,10 @@ use blockstack_lib::chainstate::stacks::TransactionPostConditionMode;
 use blockstack_lib::clarity::vm::ClarityName;
 use blockstack_lib::clarity::vm::ContractName;
 use blockstack_lib::clarity::vm::Value as ClarityValue;
-use blockstack_lib::clarity::vm::types::ListData;
-use blockstack_lib::clarity::vm::types::ListTypeData;
-use blockstack_lib::clarity::vm::types::SequenceData;
 use blockstack_lib::types::chainstate::StacksAddress;
-use clarity::vm::types::CallableData;
 use clarity::vm::types::QualifiedContractIdentifier;
 use clarity::vm::types::StandardPrincipalData;
 use clarity::vm::types::TraitIdentifier;
-use clarity::vm::types::TypeSignature;
-
-use crate::stacks::reward_claim_registry::MAX_STAKERS_LENGTH;
-use crate::stacks::reward_claim_registry::RewardClaimsBatch;
-use crate::stacks::reward_claim_registry::TUPLE_WITHDRAWAL_ITEM_SIGNATURE;
-use crate::stacks::reward_claim_registry::WithdrawalsBatch;
-
-/// The type signature for the list of 100 stakers.
-///
-/// ListTypeData::new_list only returns an Err when max size of the type
-/// could be greater than 1 MiB, or if the type depth is greater than 32.
-/// Our type depth is 1 and the max size is 148 * 100 + 6 bytes, well under
-/// 1 MiB. We also have a test that exercises this path so we know that
-/// this won't panic in production.
-static LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
-    ListTypeData::new_list(TypeSignature::PrincipalType, MAX_STAKERS_LENGTH as u32).unwrap()
-});
-
-/// The type signature for the list of 100 `{staker, request-id}` items.
-///
-/// Same size bounds as [`LIST_PRINCIPALS_SIGNATURE`]: depth is small and the
-/// max serialized size is well under 1 MiB. Exercised by the dummy
-/// `WithdrawalsBatch` contract-call test.
-static LIST_WITHDRAWAL_ITEMS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
-    let entry_type = TUPLE_WITHDRAWAL_ITEM_SIGNATURE.clone().into();
-    ListTypeData::new_list(entry_type, MAX_STAKERS_LENGTH as u32).unwrap()
-});
 
 /// The name of the trait that signer managers must implement.
 const REWARD_CLAIM_TRAIT_NAME: &str = "reward-claim-signer-manager-trait";
@@ -54,7 +21,7 @@ const REWARD_CLAIM_TRAIT_CONTRACT: &str = "reward-claim-traits";
 
 /// This function creates a Trait identifier for the
 /// [`REWARD_CLAIM_TRAIT_NAME`] trait, once we know the issuer/deployer.
-fn make_trait_identifier(deployer: StacksAddress) -> TraitIdentifier {
+pub fn make_trait_identifier(deployer: StacksAddress) -> TraitIdentifier {
     TraitIdentifier {
         name: ClarityName::from(REWARD_CLAIM_TRAIT_NAME),
         contract_identifier: QualifiedContractIdentifier {
@@ -122,65 +89,12 @@ pub trait IntoContractCall: Sized {
     }
 }
 
-impl IntoContractCall for RewardClaimsBatch {
-    /// The name of the clarity smart contract that relates to this struct.
-    const CONTRACT_NAME: &'static str = "reward-claim-registry";
-    /// The specific function name that relates to this struct.
-    const FUNCTION_NAME: &'static str = "process-reward-claims";
-    /// The stacks address that deployed the contract.
-    fn deployer_address(&self) -> &StacksAddress {
-        self.deployer()
-    }
-    /// The arguments to the clarity function.
-    fn into_contract_args(self) -> Vec<ClarityValue> {
-        let callable = CallableData {
-            contract_identifier: self.signer_manager().clone(),
-            trait_identifier: Some(make_trait_identifier(self.deployer().clone())),
-        };
-        let stakers = self.stakers().into_iter().map(ClarityValue::Principal);
-        let stakers = ListData {
-            data: stakers.collect(),
-            type_signature: LIST_PRINCIPALS_SIGNATURE.clone(),
-        };
-
-        vec![
-            ClarityValue::CallableContract(callable),
-            ClarityValue::Sequence(SequenceData::List(stakers)),
-        ]
-    }
-}
-
-impl IntoContractCall for WithdrawalsBatch {
-    /// The name of the clarity smart contract that relates to this struct.
-    const CONTRACT_NAME: &'static str = "reward-claim-registry";
-    /// The specific function name that relates to this struct.
-    const FUNCTION_NAME: &'static str = "settle-pending-withdrawals";
-    /// The stacks address that deployed the contract.
-    fn deployer_address(&self) -> &StacksAddress {
-        self.deployer()
-    }
-    /// The arguments to the clarity function.
-    fn into_contract_args(self) -> Vec<ClarityValue> {
-        let callable = CallableData {
-            contract_identifier: self.signer_manager().clone(),
-            trait_identifier: Some(make_trait_identifier(self.deployer().clone())),
-        };
-        let data = self
-            .into_items()
-            .map(|item| ClarityValue::Tuple(item.into_tuple()))
-            .collect::<Vec<_>>();
-        let type_signature = LIST_WITHDRAWAL_ITEMS_SIGNATURE.clone();
-
-        vec![
-            ClarityValue::CallableContract(callable),
-            ClarityValue::Sequence(SequenceData::List(ListData { data, type_signature })),
-        ]
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::stacks::reward_claim_registry::RewardClaimsBatch;
+    use crate::stacks::reward_claim_registry::WithdrawalsBatch;
 
     #[test]
     fn process_reward_claims_contract_call_creation() {

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -22,8 +22,8 @@ use clarity::vm::types::TypeSignature;
 
 use crate::stacks::reward_claim_registry::MAX_STAKERS_LENGTH;
 use crate::stacks::reward_claim_registry::RewardClaimsBatch;
-use crate::stacks::reward_claim_registry::SettlementsBatch;
-use crate::stacks::reward_claim_registry::TUPLE_SETTLEMENT_ITEM_SIGNATURE;
+use crate::stacks::reward_claim_registry::TUPLE_WITHDRAWAL_ITEM_SIGNATURE;
+use crate::stacks::reward_claim_registry::WithdrawalsBatch;
 
 /// The type signature for the list of 100 stakers.
 ///
@@ -40,9 +40,9 @@ static LIST_PRINCIPALS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
 ///
 /// Same size bounds as [`LIST_PRINCIPALS_SIGNATURE`]: depth is small and the
 /// max serialized size is well under 1 MiB. Exercised by the dummy
-/// `SettlementsBatch` contract-call test.
-static LIST_SETTLEMENT_ITEMS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
-    let entry_type = TUPLE_SETTLEMENT_ITEM_SIGNATURE.clone().into();
+/// `WithdrawalsBatch` contract-call test.
+static LIST_WITHDRAWAL_ITEMS_SIGNATURE: LazyLock<ListTypeData> = LazyLock::new(|| {
+    let entry_type = TUPLE_WITHDRAWAL_ITEM_SIGNATURE.clone().into();
     ListTypeData::new_list(entry_type, MAX_STAKERS_LENGTH as u32).unwrap()
 });
 
@@ -150,7 +150,7 @@ impl IntoContractCall for RewardClaimsBatch {
     }
 }
 
-impl IntoContractCall for SettlementsBatch {
+impl IntoContractCall for WithdrawalsBatch {
     /// The name of the clarity smart contract that relates to this struct.
     const CONTRACT_NAME: &'static str = "reward-claim-registry";
     /// The specific function name that relates to this struct.
@@ -169,7 +169,7 @@ impl IntoContractCall for SettlementsBatch {
             .into_items()
             .map(|item| ClarityValue::Tuple(item.into_tuple()))
             .collect::<Vec<_>>();
-        let type_signature = LIST_SETTLEMENT_ITEMS_SIGNATURE.clone();
+        let type_signature = LIST_WITHDRAWAL_ITEMS_SIGNATURE.clone();
 
         vec![
             ClarityValue::CallableContract(callable),
@@ -195,7 +195,7 @@ mod tests {
     fn settle_pending_withdrawals_contract_call_creation() {
         // This is to check that this function doesn't implicitly panic. If
         // it doesn't panic now, it can never panic at runtime.
-        let call = SettlementsBatch::dummy();
+        let call = WithdrawalsBatch::dummy();
 
         let _ = call.into_tx_payload();
     }


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/62

## Changes

* Replace the "settlement" naming with "withdrawal" throughout the repo
* Moved the implementations for a trait closer to the struct definitions themselves.
* Removed some now-unnecessary functions from the Batch structs


## Testing Information

This is a refactor, so everything should remain the same.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
