### PR TITLE
feat: add read-only functions to fetch stored data

### DIFF
--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -35,7 +35,7 @@
 
 ;; A (list 100 uint) whose only job is to bound the get-pending-claims,
 ;; get-registrations, get-pending-withdrawals, and get-withdrawals folds to
-;; at most 100 iterations per call. 
+;; at most 100 iterations per call.
 ;; @format-ignore
 (define-constant PENDING_TICKS (list
     u0 u0 u0 u0 u0 u0 u0 u0 u0 u0

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -33,9 +33,9 @@
 ;; call was in flight (same pattern as pox-5's ERR_REENTRANT_CALL).
 (define-constant ERR_REENTRANT_CALL (err u612))
 
-;; A (list 100 uint) whose only job is to bound the get-pending-claims /
-;; get-pending-withdrawals folds to at most 100 node visits per call. The
-;; element values are never read (the fold step ignores `tick`).
+;; A (list 100 uint) whose only job is to bound the get-pending-claims,
+;; get-registrations, get-pending-withdrawals, and get-withdrawals folds to
+;; at most 100 iterations per call. 
 ;; @format-ignore
 (define-constant PENDING_TICKS (list
     u0 u0 u0 u0 u0 u0 u0 u0 u0 u0
@@ -244,10 +244,11 @@
 )
 
 ;; --- Doubly-linked-list maintenance over registration-ll ---
-;; The list lets get-pending-claims walk every live registration without a global
-;; index. `registration-ll-head`/`-tail` bound the walk; each node stores its
+;; The list lets get-pending-claims and get-registrations walk every live
+;; registration without a global index. `registration-ll-head`/`-tail` bound
+;; the walk; each node stores its
 ;; prev/next key. Append is O(1) at the tail; remove splices in O(1). Both are
-;; infallible and return bool.
+;; infallible and return a boolean.
 
 ;; Append `key` at the tail (it must not already be in the list). The nested
 ;; match on the neighbor read avoids a runtime panic: the entry is always
@@ -308,7 +309,7 @@
 
 ;; --- Doubly-linked-list maintenance over pending-withdrawal-ll ---
 ;; Same shape as the registration list, one node per indexed withdrawal so
-;; get-pending-withdrawals can walk them directly.
+;; get-pending-withdrawals and get-withdrawals can walk them.
 
 ;; Append `key` at the tail of the pending-withdrawal list.
 ;;
@@ -535,6 +536,109 @@
             ;; If `node` is still `some` after the fold, ticks ran out with more
             ;; list ahead: resume after `last-visited`. If `node` is none, the
             ;; walk reached the tail or the list was empty.
+            (next (match (get node walk)
+                more-to-do (get last-visited walk)
+                none
+            ))
+        )
+        (ok {
+            rows: (get rows walk),
+            next: next,
+        })
+    )
+)
+
+;; Fold step for get-registrations. From the current `node` it reads that
+;; registration, appends the full registration merged with its key, records
+;; `last-visited`, and advances `node` to the next linked-list entry. Once
+;; `node` is none it is a no-op for the remaining ticks.
+;;
+;; #[allow(unchecked_data)]
+(define-private (registrations-step
+        (tick_ uint)
+        (acc {
+            node: (optional {
+                staker: principal,
+                signer-manager: principal,
+            }),
+            last-visited: (optional {
+                staker: principal,
+                signer-manager: principal,
+            }),
+            rows: (list 100
+                {
+                    staker: principal,
+                    signer-manager: principal,
+                    bond-index: (optional uint),
+                    remaining-cycles: uint,
+                    one-claim-per-reward-cycle: bool,
+                    next-claim-distribution: uint,
+                    prepaid-ustx: uint,
+                }
+            ),
+        })
+    )
+    (match (get node acc)
+        key
+        (let ((next-node (match (map-get? registration-ll key)
+                links (get next links)
+                none
+            )))
+            (match (map-get? registrations key)
+                registration
+                (merge acc {
+                    node: next-node,
+                    last-visited: (some key),
+                    rows: (default-to (get rows acc)
+                        (as-max-len? (append (get rows acc) (merge key registration)) u100)
+                    ),
+                })
+                ;; A live linked-list node with no registration should never
+                ;; happen; skip it defensively rather than aborting.
+                (merge acc {
+                    node: next-node,
+                    last-visited: (some key),
+                })
+            )
+        )
+        ;; Past the tail: nothing left to visit.
+        acc
+    )
+)
+
+;; List every registration.
+
+;; Walks the registration linked list from cursor, or from the head when
+;; cursor is none, and returns up to 100 rows. Unlike get-pending-claims,
+;; every visited registration is emitted. Use the returned `next` cursor:
+;; none means the walk hit the tail; some key means pass that key as the
+;; next `cursor` to resume after it.
+;;
+;; Parameters:
+;;   cursor  none to start at the head, or the `next` key from the previous
+;;           page so the walk resumes at that key's successor.
+;;
+;; Returns:
+;;   ok wrapping { rows, next }. Each row is the registration map value with
+;;   staker and signer-manager merged in. `next` is none at the tail, or the
+;;   last visited registration key when more nodes may remain.
+(define-read-only (get-registrations (cursor (optional {
+    staker: principal,
+    signer-manager: principal,
+})))
+    (let (
+            (start (match cursor
+                cursor-key (match (map-get? registration-ll cursor-key)
+                    links (get next links)
+                    none
+                )
+                (var-get registration-ll-head)
+            ))
+            (walk (fold registrations-step PENDING_TICKS {
+                node: start,
+                last-visited: none,
+                rows: (list),
+            }))
             (next (match (get node walk)
                 more-to-do (get last-visited walk)
                 none
@@ -1342,6 +1446,113 @@
                 (var-get pending-withdrawal-ll-head)
             ))
             (walk (fold pending-withdrawals-step PENDING_TICKS {
+                node: start,
+                last-visited: none,
+                rows: (list),
+            }))
+            (next (match (get node walk)
+                more-to-do (get last-visited walk)
+                none
+            ))
+        )
+        (ok {
+            rows: (get rows walk),
+            next: next,
+        })
+    )
+)
+
+;; Fold step for get-withdrawals. Visits one linked-list node, appends the
+;; withdrawal key merged with its indexed burn height, records
+;; `last-visited`, and advances `node`. Unlike pending-withdrawals-step,
+;; every stored entry is emitted.
+;;
+;; #[allow(unchecked_data)]
+(define-private (withdrawals-step
+        (tick_ uint)
+        (acc {
+            node: (optional {
+                staker: principal,
+                signer-manager: principal,
+                request-id: uint,
+            }),
+            last-visited: (optional {
+                staker: principal,
+                signer-manager: principal,
+                request-id: uint,
+            }),
+            rows: (list 100
+                {
+                    staker: principal,
+                    signer-manager: principal,
+                    request-id: uint,
+                    indexed-height: uint,
+                }
+            ),
+        })
+    )
+    (match (get node acc)
+        key
+        (let ((next-node (match (map-get? pending-withdrawal-ll key)
+                links (get next links)
+                none
+            )))
+            (match (map-get? pending-withdrawals key)
+                stored-height
+                (merge acc {
+                    node: next-node,
+                    last-visited: (some key),
+                    rows: (default-to (get rows acc)
+                        (as-max-len?
+                            (append (get rows acc) (merge key { indexed-height: stored-height }))
+                            u100
+                        )),
+                })
+                ;; A linked-list node with no pending entry should never happen;
+                ;; skip it defensively rather than aborting the read.
+                (merge acc {
+                    node: next-node,
+                    last-visited: (some key),
+                })
+            )
+        )
+        ;; Past the tail: nothing left to visit.
+        acc
+    )
+)
+
+;; List every indexed L1 withdrawal. Walks pending-withdrawal-ll from
+;; cursor, or from the head when cursor is none, and returns up to 100
+;; rows. Unlike get-pending-withdrawals, every visited entry is emitted.
+;; Use the returned `next` cursor: none means the walk hit the tail; some
+;; key means pass that key as the next `cursor` to resume after it.
+;;
+;; Parameters:
+;;
+;;   cursor  use none to start at the head. When some, it indicates where
+;;           to resume. The withdrawal for this key is not included in the
+;;           response.
+;;
+;; Returns:
+;;
+;;   ok wrapping { rows, next }. Each row has staker, signer-manager,
+;;   request-id, and indexed-height (the Bitcoin block height when the
+;;   withdrawal was indexed). `next` is none at the tail, or the last
+;;   visited key when more nodes may remain.
+(define-read-only (get-withdrawals (cursor (optional {
+    staker: principal,
+    signer-manager: principal,
+    request-id: uint,
+})))
+    (let (
+            (start (match cursor
+                cursor-key (match (map-get? pending-withdrawal-ll cursor-key)
+                    links (get next links)
+                    none
+                )
+                (var-get pending-withdrawal-ll-head)
+            ))
+            (walk (fold withdrawals-step PENDING_TICKS {
                 node: start,
                 last-visited: none,
                 rows: (list),

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -17,9 +17,7 @@
     "@types/node": "24.12.2",
     "chokidar-cli": "3.0.0",
     "vitest": "4.1.4",
-    "vitest-environment-clarinet": "3.0.2"
-  },
-  "devDependencies": {
+    "vitest-environment-clarinet": "3.0.2",
     "@vitest/expect": "4.1.4",
     "typescript": "5.9.3"
   }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -18,5 +18,9 @@
     "chokidar-cli": "3.0.0",
     "vitest": "4.1.4",
     "vitest-environment-clarinet": "3.0.2"
+  },
+  "devDependencies": {
+    "@vitest/expect": "4.1.4",
+    "typescript": "5.9.3"
   }
 }

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -665,10 +665,28 @@ export function getPendingClaims(cursor: OptionalCV = Cl.none()) {
   ).result;
 }
 
+export function getRegistrations(cursor: OptionalCV = Cl.none()) {
+  return simnet.callReadOnlyFn(
+    "reward-claim-registry",
+    "get-registrations",
+    [cursor],
+    deployer,
+  ).result;
+}
+
 export function getPendingWithdrawals(cursor: OptionalCV = Cl.none()) {
   return simnet.callReadOnlyFn(
     "reward-claim-registry",
     "get-pending-withdrawals",
+    [cursor],
+    deployer,
+  ).result;
+}
+
+export function getWithdrawals(cursor: OptionalCV = Cl.none()) {
+  return simnet.callReadOnlyFn(
+    "reward-claim-registry",
+    "get-withdrawals",
     [cursor],
     deployer,
   ).result;

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -32,8 +32,11 @@ import {
   deployer,
   fundAndCalculateRewards,
   fundAndClaimSignerRewards,
+  burnHeight,
   getPendingWithdrawals,
   getPendingClaims,
+  getRegistrations,
+  getWithdrawals,
   getEarned,
   getMaliciousLastReenterError,
   getRegistration,
@@ -149,6 +152,61 @@ function withdrawalRow(staker: string, requestId: bigint, signerManager = SIGNER
 
 function pendingWithdrawalsPage(
   rows: ReturnType<typeof withdrawalRow>[],
+  next: ClarityValue = Cl.none(),
+) {
+  return Cl.tuple({
+    rows: Cl.list(rows),
+    next,
+  });
+}
+
+/** Full registration row from `get-registrations`: map value merged with key. */
+function registrationRow(
+  staker: string,
+  remaining: bigint,
+  nextClaimDistribution: bigint,
+  prepaid: bigint = remaining * FEE_PER_CLAIM,
+  oneClaimPerRewardCycle = true,
+  bondIndex: OptionalCV<UIntCV> = Cl.none(),
+) {
+  return Cl.tuple({
+    staker: Cl.principal(staker),
+    "signer-manager": Cl.principal(SIGNER_MANAGER),
+    "bond-index": bondIndex,
+    "remaining-cycles": Cl.uint(remaining),
+    "one-claim-per-reward-cycle": Cl.bool(oneClaimPerRewardCycle),
+    "next-claim-distribution": Cl.uint(nextClaimDistribution),
+    "prepaid-ustx": Cl.uint(prepaid),
+  });
+}
+
+function registrationsPage(
+  rows: ReturnType<typeof registrationRow>[],
+  next: ClarityValue = Cl.none(),
+) {
+  return Cl.tuple({
+    rows: Cl.list(rows),
+    next,
+  });
+}
+
+/** Full withdrawal row from `get-withdrawals`: key merged with indexed-height. */
+function withdrawalEntryRow(
+  staker: string,
+  requestId: bigint,
+  indexedHeight: bigint,
+  signerManager = SIGNER_MANAGER,
+) {
+  return Cl.tuple({
+    staker: Cl.principal(staker),
+    "signer-manager": Cl.principal(signerManager),
+    "request-id": Cl.uint(requestId),
+    "indexed-height": Cl.uint(indexedHeight),
+  });
+}
+
+function withdrawalsPage(
+  rows: ReturnType<typeof withdrawalEntryRow>[],
   next: ClarityValue = Cl.none(),
 ) {
   return Cl.tuple({
@@ -765,6 +823,140 @@ describe("get-pending-claims", () => {
   );
 });
 
+describe("get-registrations", () => {
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    stakeFor(wallet1, SIGNER_SET_MIN_USTX, 2n);
+  });
+
+  it("is empty when nothing is registered", () => {
+    expect(getRegistrations()).toBeOk(registrationsPage([]));
+  });
+
+  it("lists a registration before its claim is pending", () => {
+    registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    expect(getPendingClaims()).toBeOk(pendingClaimsPage([]));
+    expect(getRegistrations()).toBeOk(
+      registrationsPage([registrationRow(wallet1, 1n, STX_FIRST_CLAIM_DIST)]),
+    );
+  });
+
+  it("walks multiple registrations in insertion order", () => {
+    stakeFor(wallet2, SIGNER_SET_MIN_USTX, 2n);
+    registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, 2n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    expect(getRegistrations()).toBeOk(
+      registrationsPage([
+        registrationRow(wallet1, 1n, STX_FIRST_CLAIM_DIST),
+        registrationRow(wallet2, 2n, STX_FIRST_CLAIM_DIST),
+      ]),
+    );
+  });
+
+  it("keeps a registration after it is claimed (unlike get-pending-claims)", () => {
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+    expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeOk(Cl.none());
+
+    expect(getPendingClaims()).toBeOk(pendingClaimsPage([]));
+    expect(getRegistrations()).toBeOk(
+      registrationsPage([registrationRow(wallet1, 2n, STX_FIRST_CLAIM_DIST + 2n)]),
+    );
+  });
+
+  it("drops a registration after cancel", () => {
+    stakeFor(wallet2, SIGNER_SET_MIN_USTX, 2n);
+    registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "cancel-registration",
+        [Cl.principal(wallet1), Cl.principal(SIGNER_MANAGER)],
+        wallet1,
+      ).result,
+    ).toBeOk(Cl.uint(FEE_PER_CLAIM));
+
+    expect(getRegistrations()).toBeOk(
+      registrationsPage([registrationRow(wallet2, 1n, STX_FIRST_CLAIM_DIST)]),
+    );
+  });
+
+  it(
+    "paginates every registration across >100 nodes",
+    () => {
+      const TOTAL = 220;
+
+      const stakers = Array.from({ length: TOTAL }, (_, i) => {
+        const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+        return privateKeyToAddress(hex, "testnet");
+      });
+
+      for (const staker of stakers) {
+        expect(
+          simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+        ).toBeOk(Cl.bool(true));
+        stakeFor(staker, SIGNER_SET_MIN_USTX, 2n);
+        expect(
+          registerForClaims(staker, FEE_PER_CLAIM, deployer, SIGNER_MANAGER, STX_START, true)
+            .result,
+        ).toBeOk(Cl.uint(1));
+      }
+
+      const all: string[] = [];
+      let cursor: OptionalCV = Cl.none();
+      const pageSizes: number[] = [];
+      for (let guard = 0; guard < 10; guard++) {
+        const json = cvToJSON(getRegistrations(cursor));
+        expect(json.success).toBe(true);
+        const page = json.value.value as {
+          rows: {
+            value: Array<{
+              value: {
+                staker: { value: string };
+                "remaining-cycles": { value: string };
+                "next-claim-distribution": { value: string };
+              };
+            }>;
+          };
+          next: {
+            value: null | {
+              value: { staker: { value: string }; "signer-manager": { value: string } };
+            };
+          };
+        };
+
+        const rowStakers = page.rows.value.map((row) => row.value.staker.value);
+        pageSizes.push(rowStakers.length);
+        for (const row of page.rows.value) {
+          expect(row.value["remaining-cycles"].value).toBe("1");
+          expect(row.value["next-claim-distribution"].value).toBe(
+            STX_FIRST_CLAIM_DIST.toString(),
+          );
+        }
+        all.push(...rowStakers);
+
+        if (page.next.value === null) {
+          break;
+        }
+        const nextKey = page.next.value.value;
+        cursor = Cl.some(
+          Cl.tuple({
+            staker: Cl.principal(nextKey.staker.value),
+            "signer-manager": Cl.principal(nextKey["signer-manager"].value),
+          }),
+        );
+      }
+
+      expect(pageSizes).toEqual([100, 100, 20]);
+      expect(all).toEqual(stakers);
+    },
+    180_000,
+  );
+});
+
 describe("process-reward-claim (direct sBTC payout)", () => {
   beforeEach(() => {
     initPox5();
@@ -1336,6 +1528,165 @@ describe("get-pending-withdrawals pagination", () => {
         ),
       );
       expect(second).toBeOk(pendingWithdrawalsPage([withdrawalRow(lastStaker, lastId)]));
+    },
+    300_000,
+  );
+});
+
+describe("get-withdrawals", () => {
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    stakeWithPoxAddr(wallet1, SIGNER_SET_MIN_USTX, 2n, 100n);
+    stakeWithPoxAddr(wallet2, SIGNER_SET_MIN_USTX, 2n, 100n);
+    fundAndClaimSignerRewards(2000n, 1n);
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+  });
+
+  it("is empty when nothing is indexed", () => {
+    expect(getWithdrawals()).toBeOk(withdrawalsPage([]));
+  });
+
+  it("lists an indexed withdrawal immediately, before it is settleable", () => {
+    expect(processRewardClaim(wallet1, wallet1, SIGNER_MANAGER).result).toBeOk(Cl.some(Cl.uint(1)));
+    const indexedHeight = burnHeight();
+
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
+    expect(getWithdrawals()).toBeOk(
+      withdrawalsPage([withdrawalEntryRow(wallet1, 1n, indexedHeight)]),
+    );
+  });
+
+  it("lists still-pending withdrawals even after the age gate", () => {
+    processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
+    const indexedHeight = burnHeight();
+    mineUntilWithdrawalListable();
+
+    expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
+    expect(getWithdrawals()).toBeOk(
+      withdrawalsPage([withdrawalEntryRow(wallet1, 1n, indexedHeight)]),
+    );
+  });
+
+  it("walks multiple withdrawals in insertion order", () => {
+    processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
+    const height1 = burnHeight();
+    processRewardClaim(wallet2, wallet2, SIGNER_MANAGER);
+    const height2 = burnHeight();
+
+    expect(getWithdrawals()).toBeOk(
+      withdrawalsPage([
+        withdrawalEntryRow(wallet1, 1n, height1),
+        withdrawalEntryRow(wallet2, 2n, height2),
+      ]),
+    );
+  });
+
+  it("drops a withdrawal after it is settled", () => {
+    processRewardClaim(wallet1, wallet1, SIGNER_MANAGER);
+    processRewardClaim(wallet2, wallet2, SIGNER_MANAGER);
+    const height2 = burnHeight();
+    rejectWithdrawal(1n);
+    expect(settlePendingWithdrawal(wallet1, 1n, deployer).result).toBeOk(Cl.bool(true));
+
+    expect(getWithdrawals()).toBeOk(
+      withdrawalsPage([withdrawalEntryRow(wallet2, 2n, height2)]),
+    );
+  });
+});
+
+describe("get-withdrawals pagination", () => {
+  it(
+    "paginates every indexed withdrawal across >100 nodes",
+    () => {
+      const TOTAL = 220;
+      initPox5();
+      registerSignerManager(SIGNER_PRIVATE_KEY);
+
+      const stakers = Array.from({ length: TOTAL }, (_, i) => {
+        const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+        return privateKeyToAddress(hex, "testnet");
+      });
+
+      for (const staker of stakers) {
+        expect(
+          simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+        ).toBeOk(Cl.bool(true));
+        stakeWithPoxAddr(staker, SIGNER_SET_MIN_USTX, 2n, 100n);
+        expect(
+          registerForClaims(staker, FEE_PER_CLAIM, deployer, SIGNER_MANAGER, STX_START, true)
+            .result,
+        ).toBeOk(Cl.uint(1));
+      }
+
+      fundAndClaimSignerRewards(500_000n, 1n);
+      mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
+
+      const expected: { staker: string; requestId: bigint; indexedHeight: bigint }[] = [];
+      for (let i = 0; i < TOTAL; i++) {
+        const staker = stakers[i]!;
+        const { result } = processRewardClaim(staker, deployer, SIGNER_MANAGER);
+        expect(result).toBeOk(Cl.some(Cl.uint(BigInt(i + 1))));
+        expected.push({
+          staker,
+          requestId: BigInt(i + 1),
+          indexedHeight: burnHeight(),
+        });
+      }
+
+      const listed: { staker: string; requestId: bigint; indexedHeight: bigint }[] = [];
+      let cursor: OptionalCV = Cl.none();
+      const pageSizes: number[] = [];
+      for (let guard = 0; guard < 10; guard++) {
+        const json = cvToJSON(getWithdrawals(cursor));
+        expect(json.success).toBe(true);
+        const page = json.value.value as {
+          rows: {
+            value: Array<{
+              value: {
+                staker: { value: string };
+                "request-id": { value: string };
+                "indexed-height": { value: string };
+              };
+            }>;
+          };
+          next: {
+            value: null | {
+              value: {
+                staker: { value: string };
+                "signer-manager": { value: string };
+                "request-id": { value: string };
+              };
+            };
+          };
+        };
+
+        pageSizes.push(page.rows.value.length);
+        for (const row of page.rows.value) {
+          listed.push({
+            staker: row.value.staker.value,
+            requestId: BigInt(row.value["request-id"].value),
+            indexedHeight: BigInt(row.value["indexed-height"].value),
+          });
+        }
+
+        if (page.next.value === null) {
+          break;
+        }
+        const nextKey = page.next.value.value;
+        cursor = Cl.some(
+          Cl.tuple({
+            staker: Cl.principal(nextKey.staker.value),
+            "signer-manager": Cl.principal(nextKey["signer-manager"].value),
+            "request-id": Cl.uint(BigInt(nextKey["request-id"].value)),
+          }),
+        );
+      }
+
+      expect(pageSizes).toEqual([100, 100, 20]);
+      expect(listed).toEqual(expected);
     },
     300_000,
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,22 +19,21 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
+      '@vitest/expect':
+        specifier: 4.1.4
+        version: 4.1.4
       chokidar-cli:
         specifier: 3.0.0
         version: 3.0.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
       vitest-environment-clarinet:
         specifier: 3.0.2
         version: 3.0.2(@stacks/clarinet-sdk@3.23.1)(vitest@4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
-    devDependencies:
-      '@vitest/expect':
-        specifier: 4.1.4
-        version: 4.1.4
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
   tests:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,13 @@ importers:
       vitest-environment-clarinet:
         specifier: 3.0.2
         version: 3.0.2(@stacks/clarinet-sdk@3.23.1)(vitest@4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)))
+    devDependencies:
+      '@vitest/expect':
+        specifier: 4.1.4
+        version: 4.1.4
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
   tests:
     dependencies:


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/68.

These functions are not meant to have corresponding fetchers in spox; they're here just in case we need them for a migration or for general information.

## Changes

* Add read-only functions for fetching all registrations and all withdrawal request IDs stored within the smart contract.

## Testing Information

Added some unit tests.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
