### PR TITLE
feat: use `fast-read-only` RPC calls and originator post-conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
 dependencies = [
- "clarity-types",
+ "clarity-types 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
  "integer-sqrt",
  "lazy_static",
  "regex",
@@ -368,7 +368,40 @@ dependencies = [
  "serde_json",
  "serde_stacker",
  "slog",
- "stacks-common",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
+]
+
+[[package]]
+name = "clarity"
+version = "0.0.1"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+dependencies = [
+ "clarity-types 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5)",
+ "integer-sqrt",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_stacker",
+ "slog",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5)",
+]
+
+[[package]]
+name = "clarity-types"
+version = "0.0.1"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "rusqlite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slog",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
+ "variant_count",
 ]
 
 [[package]]
@@ -378,12 +411,10 @@ source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790
 dependencies = [
  "lazy_static",
  "regex",
- "rusqlite",
  "serde",
  "serde_derive",
- "serde_json",
  "slog",
- "stacks-common",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5)",
 ]
 
 [[package]]
@@ -1488,12 +1519,12 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
 dependencies = [
- "clarity",
+ "clarity 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
  "serde",
  "sha2 0.10.9",
- "stacks-common",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
 ]
 
 [[package]]
@@ -1768,11 +1799,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
 dependencies = [
- "clarity",
+ "clarity 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
  "slog",
- "stacks-common",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
 ]
 
 [[package]]
@@ -2207,12 +2238,12 @@ version = "0.1.0"
 source = "git+https://github.com/stacks-sbtc/sbtc.git?rev=b2865dd9e63fb143c6b427c0c4a013233a52f283#b2865dd9e63fb143c6b427c0c4a013233a52f283"
 dependencies = [
  "bitcoin",
- "clarity",
+ "clarity 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5)",
  "rand 0.8.6",
  "secp256k1 0.29.1",
  "serde",
  "serde_json",
- "stacks-common",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5)",
  "thiserror 2.0.18",
 ]
 
@@ -2619,7 +2650,7 @@ dependencies = [
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "clap",
- "clarity",
+ "clarity 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
  "config",
  "emily-client",
  "lru",
@@ -2659,9 +2690,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "stacks-codec"
+version = "0.1.0"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
+dependencies = [
+ "clarity-types 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
+ "serde",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
+ "variant_count",
+]
+
+[[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -2688,11 +2730,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "stackslib"
+name = "stacks-common"
 version = "0.0.1"
 source = "git+https://github.com/stacks-network/stacks-core?rev=1cba695b09690790b1220b0f5d149f70f78ddea5#1cba695b09690790b1220b0f5d149f70f78ddea5"
 dependencies = [
- "clarity",
+ "chrono",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "hashbrown 0.15.4",
+ "lazy_static",
+ "libsecp256k1",
+ "p256",
+ "ripemd",
+ "secp256k1 0.24.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.9",
+ "sha3",
+ "slog",
+ "slog-term",
+ "thiserror 1.0.69",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "stackslib"
+version = "0.0.1"
+source = "git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303#1b57c3fb6709ab927f9179ab6814f874c84f5303"
+dependencies = [
+ "clarity 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
  "ed25519-dalek",
  "lazy_static",
  "libstackerdb",
@@ -2706,13 +2773,15 @@ dependencies = [
  "regex",
  "ripemd",
  "rusqlite",
+ "secp256k1 0.24.3",
  "serde",
  "serde_derive",
  "serde_json",
  "sha2 0.10.9",
  "siphasher",
  "slog",
- "stacks-common",
+ "stacks-codec",
+ "stacks-common 0.0.1 (git+https://github.com/stacks-network/stacks-core?rev=1b57c3fb6709ab927f9179ab6814f874c84f5303)",
  "time",
  "toml 0.5.11",
  "url",
@@ -3174,6 +3243,17 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "variant_count"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c13b28baa922722e35ded153b394d0247b4942b4ad54f85713a7de672cdf0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ testing = []
 sbtc = { git = "https://github.com/stacks-sbtc/sbtc.git", rev = "b2865dd9e63fb143c6b427c0c4a013233a52f283", default-features = false }
 emily-client = { git = "https://github.com/stacks-sbtc/sbtc.git", rev = "b2865dd9e63fb143c6b427c0c4a013233a52f283", default-features = false }
 
-clarity = { git = "https://github.com/stacks-network/stacks-core", rev = "1cba695b09690790b1220b0f5d149f70f78ddea5", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core", rev = "1cba695b09690790b1220b0f5d149f70f78ddea5", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core", rev = "1b57c3fb6709ab927f9179ab6814f874c84f5303", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core", rev = "1b57c3fb6709ab927f9179ab6814f874c84f5303", default-features = false }
 
 bitcoin = { version = "0.32.8", default-features = false, features = ["serde", "rand-std"] }
 bitcoincore-rpc = { version = "0.19.0", default-features = false }

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -92,6 +92,12 @@ reclaim_script = "75206c44dfe47941b0271c642c549d9a763afce7c6b0495c72f1a32c2f0989
 # Environment: SPOX_STACKS__RPC_ENDPOINT
 rpc_endpoint = "http://127.0.0.1:20443"
 
+# Token sent as the Authorization header for stacks-core privileged RPC.
+#
+# Required: false
+# Environment: SPOX_STACKS__AUTH_TOKEN
+auth_token = "12345"
+
 # The address of the deployer of the sBTC smart contracts.
 #
 # Required: true (when this stanza is present)

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -94,7 +94,7 @@ rpc_endpoint = "http://127.0.0.1:20443"
 
 # Token sent as the Authorization header for stacks-core privileged RPC.
 #
-# Required: false
+# Required: true (when the this stanza is present)
 # Environment: SPOX_STACKS__AUTH_TOKEN
 auth_token = "12345"
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,6 +81,9 @@ pub struct StacksConfig {
     /// Stacks rpc endpoint
     #[serde(deserialize_with = "url_deserializer")]
     pub rpc_endpoint: Url,
+    /// Token sent as the `Authorization` header for stacks-core privileged
+    /// RPC.
+    pub auth_token: Option<String>,
     /// The address of the deployer of the sBTC smart contracts.
     #[serde(deserialize_with = "stacks_address_deserializer")]
     pub sbtc_deployer: StacksAddress,
@@ -229,7 +232,9 @@ mod tests {
         assert_eq!(settings.bitcoin_rpc_timeout, Duration::from_mins(5));
         assert!(settings.registry_contract.is_none());
         assert!(settings.reward_claims.is_none());
-        settings.stacks.as_ref().unwrap();
+        let stacks = settings.stacks.as_ref().unwrap();
+        assert_eq!(stacks.rpc_endpoint, parse_url("http://127.0.0.1:20443"));
+        assert_eq!(stacks.auth_token.as_deref(), Some("12345"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -83,7 +83,7 @@ pub struct StacksConfig {
     pub rpc_endpoint: Url,
     /// Token sent as the `Authorization` header for stacks-core privileged
     /// RPC.
-    pub auth_token: Option<String>,
+    pub auth_token: String,
     /// The address of the deployer of the sBTC smart contracts.
     #[serde(deserialize_with = "stacks_address_deserializer")]
     pub sbtc_deployer: StacksAddress,
@@ -234,7 +234,7 @@ mod tests {
         assert!(settings.reward_claims.is_none());
         let stacks = settings.stacks.as_ref().unwrap();
         assert_eq!(stacks.rpc_endpoint, parse_url("http://127.0.0.1:20443"));
-        assert_eq!(stacks.auth_token.as_deref(), Some("12345"));
+        assert_eq!(stacks.auth_token, "12345");
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,19 +17,16 @@ pub enum Error {
     BitcoinCoreRpcClient(#[source] jsonrpc::http::simple_http::Error, String),
 
     /// Could not serialize the clarity value to bytes.
-    ///
-    /// For some reason, InterpreterError does not implement
-    /// std::fmt::Display or std::error::Error, hence the debug log.
     #[error("clarity serialization error: {0:?}")]
-    ClarityValueSerialization(Box<clarity::vm::errors::InterpreterError>),
+    ClarityValueSerialization(Box<clarity::vm::types::serialization::SerializationError>),
 
     /// Could not create a clarity list. This shouldn't happen.
     #[error("clarity bad list: {0:?}")]
-    ClarityBadList(Box<clarity::vm::errors::Error>),
+    ClarityBadList(Box<clarity::vm::errors::ClarityTypeError>),
 
     /// Could not construct a clarity value.
     #[error("clarity construction error: {0:?}")]
-    ClarityTuple(Box<clarity::vm::errors::Error>),
+    ClarityTuple(Box<clarity::vm::errors::ClarityTypeError>),
 
     /// Missing an expected tuple entry. This shouldn't happen.
     #[error("missing an expected tuple entry: {0}")]
@@ -141,4 +138,8 @@ pub enum Error {
     /// Failed to parse a hex-encoded integer from a Stacks node response.
     #[error("could not parse hex integer: {0}")]
     ParseHexInt(#[source] std::num::ParseIntError),
+
+    /// Failed to parse a JSON response from the Stacks node.
+    #[error("failed to transform a PrincipalData into or from JSON: {0}")]
+    PrincipalDataSerdeJson(#[source] serde_json::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,11 @@ pub enum Error {
     #[error("could not parse the provided URL: {0}")]
     InvalidUrl(#[source] url::ParseError),
 
+    /// The Stacks RPC auth token cannot be used as an HTTP `Authorization`
+    /// header value.
+    #[error("stacks rpc auth token is not a valid HTTP header value: {0}")]
+    InvalidStacksAuthToken(#[source] reqwest::header::InvalidHeaderValue),
+
     /// Poisoned mutex
     #[error("poisoned mutex")]
     PoisonedMutex,

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,10 @@ pub enum Error {
     #[error("could not create RPC client to {1}: {0}")]
     BitcoinCoreRpcClient(#[source] jsonrpc::http::simple_http::Error, String),
 
+    /// Could not deserialize the clarity value from a hex-encoded string.
+    #[error("clarity deserialization error: {0:?}")]
+    ClarityValueDeserialization(Box<clarity::vm::types::serialization::SerializationError>),
+
     /// Could not serialize the clarity value to bytes.
     #[error("clarity serialization error: {0:?}")]
     ClarityValueSerialization(Box<clarity::vm::types::serialization::SerializationError>),
@@ -142,4 +146,10 @@ pub enum Error {
     /// Failed to parse a JSON response from the Stacks node.
     #[error("failed to transform a PrincipalData into or from JSON: {0}")]
     PrincipalDataSerdeJson(#[source] serde_json::Error),
+
+    /// A `/v3/contracts/fast-call-read` request returned `okay: false`.
+    ///
+    /// The node still answers HTTP 200; the Clarity VM error is in `cause`.
+    #[error("read-only stacks call failed: {0:?}")]
+    ReadOnlyCallFailed(Option<String>),
 }

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -185,7 +185,7 @@ impl RewardClaimState {
         };
 
         // Let's go and get the current chain id.
-        let client = StacksClient::new(stacks.rpc_endpoint.clone(), stacks.auth_token.as_deref())?;
+        let client = StacksClient::new(stacks.rpc_endpoint.clone(), &stacks.auth_token)?;
         let info = client.get_node_info().await?;
         let wallet = StacksWallet::new(config.private_key, info.chain_id, 0);
 

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -73,7 +73,7 @@ pub async fn process_reward_claims(mut rx: mpsc::Receiver<BlockRef>, context: Co
 /// 2. Submits a process-reward-claims contract call for each batch of
 ///    claims, where a batch is a group of at most 100 stakers who are
 ///    associated with the same signer-manager.
-#[instrument(skip(state))]
+#[instrument(skip_all, fields(bitcoin_block_height = %chain_tip.block_height, bitcoin_block_hash = %chain_tip.block_hash))]
 async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Result<(), Error> {
     let batches = state.registry.get_pending_claim_batches().await?;
     if batches.is_empty() {
@@ -121,7 +121,7 @@ async fn process_claims(state: &RewardClaimState, chain_tip: &BlockRef) -> Resul
 /// 2. Submits a settle-pending-withdrawals contract call for each batch of
 ///    withdrawals, where a batch is a group of at most 100 withdrawals who
 ///    are associated with the same signer-manager.
-#[instrument(skip(state))]
+#[instrument(skip_all, fields(bitcoin_block_height = %chain_tip.block_height, bitcoin_block_hash = %chain_tip.block_hash))]
 async fn process_withdrawals(state: &RewardClaimState, chain_tip: &BlockRef) -> Result<(), Error> {
     let batches = state.registry.get_pending_withdrawal_batches().await?;
     if batches.is_empty() {

--- a/src/reward_claim_process.rs
+++ b/src/reward_claim_process.rs
@@ -185,7 +185,7 @@ impl RewardClaimState {
         };
 
         // Let's go and get the current chain id.
-        let client = StacksClient::new(stacks.rpc_endpoint.clone())?;
+        let client = StacksClient::new(stacks.rpc_endpoint.clone(), stacks.auth_token.as_deref())?;
         let info = client.get_node_info().await?;
         let wallet = StacksWallet::new(config.private_key, info.chain_id, 0);
 

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -202,10 +202,10 @@ impl StacksClient {
     ///
     /// When `auth_token` is set, it is sent as the raw `Authorization` header
     /// that stacks-core privileged RPC endpoints expect.
-    pub fn new(url: Url, auth_token: Option<&str>) -> Result<Self, Error> {
+    pub fn new(url: Url, auth_token: &str) -> Result<Self, Error> {
         let mut headers = HeaderMap::new();
-        if let Some(token) = auth_token.filter(|token| !token.is_empty()) {
-            let val = HeaderValue::from_str(token).map_err(Error::InvalidStacksAuthToken)?;
+        if !auth_token.is_empty() {
+            let val = HeaderValue::from_str(auth_token).map_err(Error::InvalidStacksAuthToken)?;
             headers.insert(AUTHORIZATION, val);
         }
 
@@ -442,7 +442,7 @@ impl TryFrom<&Settings> for StacksClient {
             .as_ref()
             .ok_or_else(|| Error::MissingStacksConfig)?;
 
-        let auth_token = stacks_config.auth_token.as_deref();
+        let auth_token = &stacks_config.auth_token;
         StacksClient::new(stacks_config.rpc_endpoint.clone(), auth_token)
     }
 }
@@ -579,7 +579,7 @@ mod tests {
 
         // Setup our Stacks client
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let sbtc_deployer =
             StacksAddress::from_string("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap();
@@ -635,7 +635,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let account = client.get_account(&address).await.unwrap();
         assert_eq!(
@@ -683,7 +683,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let info = client.get_node_info().await.unwrap();
         assert_eq!(info.chain_id, blockstack_lib::core::CHAIN_ID_TESTNET);
@@ -720,7 +720,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, Some("s3cret")).unwrap();
+        let client = StacksClient::new(client_url, "s3cret").unwrap();
 
         client.get_node_info().await.unwrap();
         mock.assert();
@@ -745,7 +745,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         client.get_node_info().await.unwrap();
         mock.assert();

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -31,7 +31,7 @@ pub struct DataVarResponse {
     pub data: Value,
 }
 
-/// The request body for a POST /v2/contracts/call-read/<contract-principal>/<contract-name>/<fn-name> request.
+/// The request body for a POST /v3/contracts/fast-call-read/<contract-principal>/<contract-name>/<fn-name> request.
 #[derive(Debug, serde::Serialize)]
 pub struct CallReadRequest {
     /// The simulated address of the sender.
@@ -40,12 +40,35 @@ pub struct CallReadRequest {
     pub arguments: Vec<String>,
 }
 
-/// The response from a POST /v2/contracts/call-read/<contract-principal>/<contract-name>/<fn-name> request.
+/// The response from a POST /v3/contracts/fast-call-read/<contract-principal>/<contract-name>/<fn-name>
+/// request.
+///
+/// There is an okay field here too, that we omit.
+/// https://github.com/stacks-network/stacks-core/blob/4.0.1/stackslib/src/net/api/callreadonly.rs#L52-L61
 #[derive(Debug, Deserialize)]
 pub struct CallReadResponse {
-    /// The result of the function call.
-    #[serde(deserialize_with = "clarity_value_deserializer")]
-    pub result: Value,
+    /// Whether the read-only function ran to completion.
+    pub okay: bool,
+    /// Hex-encoded Clarity value. Present when [`Self::okay`] is true.
+    #[serde(default)]
+    pub result: Option<String>,
+    /// VM error string. Present when [`Self::okay`] is false.
+    #[serde(default)]
+    pub cause: Option<String>,
+}
+
+impl CallReadResponse {
+    /// Convert a call-read JSON body into a Clarity value.
+    /// 
+    /// You can only get cause or result in the response body, not both.
+    /// https://github.com/stacks-network/stacks-core/blob/4.0.1/stackslib/src/net/api/fastcallreadonly.rs#L276-L302
+    fn into_value(self) -> Result<Value, Error> {
+        let Some(hex) = self.result else {
+            return Err(Error::ReadOnlyCallFailed(self.cause))
+        };
+        Value::try_deserialize_hex_untyped(&hex)
+            .map_err(|error| Error::ClarityValueDeserialization(Box::new(error)))
+    }
 }
 
 /// JSON body returned by GET /v2/accounts/<principal>.
@@ -240,7 +263,7 @@ impl StacksClient {
             .map(|tip| tip.to_string())
             .unwrap_or_else(|| "latest".to_string());
         let path = format!(
-            "/v2/contracts/call-read/{contract_principal}/{contract_name}/{fn_name}?tip={tip}"
+            "/v3/contracts/fast-call-read/{contract_principal}/{contract_name}/{fn_name}?tip={tip}"
         );
 
         let url = self
@@ -272,6 +295,7 @@ impl StacksClient {
         let response = self
             .client
             .post(url)
+            .header("authorization", "12345")
             .json(&body)
             .send()
             .await
@@ -283,7 +307,7 @@ impl StacksClient {
             .json::<CallReadResponse>()
             .await
             .map_err(Error::UnexpectedStacksResponse)
-            .map(|x| x.result)
+            .and_then(CallReadResponse::into_value)
     }
 
     /// Get the latest account info for the given address.
@@ -463,6 +487,45 @@ mod tests {
                 PublicKey::from_private_key(SECP256K1, &PrivateKey::generate(NetworkKind::Test))
             })
             .collect()
+    }
+
+    #[test]
+    fn call_read_response_deserializes_empty_page() {
+        let raw = r#"{"okay":true,"result":"0x070c00000002046e6578740904726f77730b00000000"}"#;
+        let value = serde_json::from_str::<CallReadResponse>(raw)
+            .unwrap()
+            .into_value()
+            .unwrap();
+
+        let expected = Value::okay(Value::Tuple(
+            clarity::vm::types::TupleData::from_data(vec![
+                (ClarityName::from_literal("next"), Value::none()),
+                (
+                    ClarityName::from_literal("rows"),
+                    Value::cons_list_unsanitized(Vec::new()).unwrap(),
+                ),
+            ])
+            .unwrap(),
+        ))
+        .unwrap();
+
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn call_read_response_cost_exceeded_is_an_error() {
+        let raw = r#"{"okay":false,"cause":"RuntimeCheck(CostBalanceExceeded(ExecutionCost { write_length: 0, write_count: 0, read_length: 206311, read_count: 7, runtime: 210725 }, ExecutionCost { write_length: 0, write_count: 0, read_length: 200000, read_count: 100, runtime: 1000000000 }))"}"#;
+        let err = serde_json::from_str::<CallReadResponse>(raw)
+            .unwrap()
+            .into_value()
+            .unwrap_err();
+
+        match err {
+            Error::ReadOnlyCallFailed(cause) => {
+                assert!(cause.is_some_and(|cause| cause.contains("CostBalanceExceeded")));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test_case(false; "some")]

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -389,8 +389,8 @@ impl StacksClient {
         let value = self
             .get_data_var(
                 sbtc_deployer,
-                &ContractName::from("sbtc-registry"),
-                &ClarityName::from("current-aggregate-pubkey"),
+                &ContractName::from_literal("sbtc-registry"),
+                &ClarityName::from_literal("current-aggregate-pubkey"),
             )
             .await?;
 

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -13,8 +13,11 @@ use clarity::types::chainstate::StacksAddress;
 use clarity::types::chainstate::StacksBlockId;
 use clarity::vm::types::{BuffData, SequenceData};
 use clarity::vm::{ClarityName, ContractName, Value};
+use reqwest::header::AUTHORIZATION;
 use reqwest::header::CONTENT_LENGTH;
 use reqwest::header::CONTENT_TYPE;
+use reqwest::header::HeaderMap;
+use reqwest::header::HeaderValue;
 use serde::{Deserialize, Deserializer};
 use url::Url;
 
@@ -59,12 +62,12 @@ pub struct CallReadResponse {
 
 impl CallReadResponse {
     /// Convert a call-read JSON body into a Clarity value.
-    /// 
+    ///
     /// You can only get cause or result in the response body, not both.
     /// https://github.com/stacks-network/stacks-core/blob/4.0.1/stackslib/src/net/api/fastcallreadonly.rs#L276-L302
     fn into_value(self) -> Result<Value, Error> {
         let Some(hex) = self.result else {
-            return Err(Error::ReadOnlyCallFailed(self.cause))
+            return Err(Error::ReadOnlyCallFailed(self.cause));
         };
         Value::try_deserialize_hex_untyped(&hex)
             .map_err(|error| Error::ClarityValueDeserialization(Box::new(error)))
@@ -195,11 +198,20 @@ pub struct StacksClient {
 }
 
 impl StacksClient {
-    /// Create a new instance of the Stacks client using the given
-    /// StacksSettings.
-    pub fn new(url: Url) -> Result<Self, Error> {
+    /// Create a new instance of the Stacks client.
+    ///
+    /// When `auth_token` is set, it is sent as the raw `Authorization` header
+    /// that stacks-core privileged RPC endpoints expect.
+    pub fn new(url: Url, auth_token: Option<&str>) -> Result<Self, Error> {
+        let mut headers = HeaderMap::new();
+        if let Some(token) = auth_token.filter(|token| !token.is_empty()) {
+            let val = HeaderValue::from_str(token).map_err(Error::InvalidStacksAuthToken)?;
+            headers.insert(AUTHORIZATION, val);
+        }
+
         let client = reqwest::Client::builder()
             .timeout(REQUEST_TIMEOUT)
+            .default_headers(headers)
             .build()?;
 
         Ok(Self { endpoint: url, client })
@@ -295,7 +307,6 @@ impl StacksClient {
         let response = self
             .client
             .post(url)
-            .header("authorization", "12345")
             .json(&body)
             .send()
             .await
@@ -431,7 +442,8 @@ impl TryFrom<&Settings> for StacksClient {
             .as_ref()
             .ok_or_else(|| Error::MissingStacksConfig)?;
 
-        StacksClient::new(stacks_config.rpc_endpoint.clone())
+        let auth_token = stacks_config.auth_token.as_deref();
+        StacksClient::new(stacks_config.rpc_endpoint.clone(), auth_token)
     }
 }
 
@@ -567,7 +579,7 @@ mod tests {
 
         // Setup our Stacks client
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let sbtc_deployer =
             StacksAddress::from_string("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM").unwrap();
@@ -623,7 +635,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let account = client.get_account(&address).await.unwrap();
         assert_eq!(
@@ -671,7 +683,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let info = client.get_node_info().await.unwrap();
         assert_eq!(info.chain_id, blockstack_lib::core::CHAIN_ID_TESTNET);
@@ -686,6 +698,56 @@ mod tests {
             info.stacks_tip_consensus_hash,
             ConsensusHash::from_hex("dfe87cfd31c1a67fa8b989c83b79aa476e616758").unwrap()
         );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn auth_token_is_sent_as_authorization_header() {
+        let raw_json_response = r#"{
+            "network_id": 2147483648,
+            "stacks_tip": "b5f9aa4423ffa7abb585fc00e2783c40225597ec112ee618db86ae23dbbbe88c",
+            "stacks_tip_consensus_hash": "dfe87cfd31c1a67fa8b989c83b79aa476e616758"
+        }"#;
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock("GET", "/v2/info")
+            .match_header("authorization", "s3cret")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url, Some("s3cret")).unwrap();
+
+        client.get_node_info().await.unwrap();
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn missing_auth_token_omits_authorization_header() {
+        let raw_json_response = r#"{
+            "network_id": 2147483648,
+            "stacks_tip": "b5f9aa4423ffa7abb585fc00e2783c40225597ec112ee618db86ae23dbbbe88c",
+            "stacks_tip_consensus_hash": "dfe87cfd31c1a67fa8b989c83b79aa476e616758"
+        }"#;
+
+        let mut stacks_node_server = mockito::Server::new_async().await;
+        let mock = stacks_node_server
+            .mock("GET", "/v2/info")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(raw_json_response)
+            .expect(1)
+            .create();
+
+        let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
+
+        client.get_node_info().await.unwrap();
         mock.assert();
     }
 }

--- a/src/stacks/node.rs
+++ b/src/stacks/node.rs
@@ -44,14 +44,12 @@ pub struct CallReadRequest {
 }
 
 /// The response from a POST /v3/contracts/fast-call-read/<contract-principal>/<contract-name>/<fn-name>
-/// request.
+/// and POST /v2/contracts/call-read/<contract-principal>/<contract-name>/<fn-name> requests.
 ///
 /// There is an okay field here too, that we omit.
 /// https://github.com/stacks-network/stacks-core/blob/4.0.1/stackslib/src/net/api/callreadonly.rs#L52-L61
 #[derive(Debug, Deserialize)]
 pub struct CallReadResponse {
-    /// Whether the read-only function ran to completion.
-    pub okay: bool,
     /// Hex-encoded Clarity value. Present when [`Self::okay`] is true.
     #[serde(default)]
     pub result: Option<String>,

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -64,7 +64,7 @@ impl DepositAddressRegistry {
             .call_read(
                 &self.contract_principal,
                 &self.contract_name,
-                &ClarityName::from("get-next-address-id"),
+                &ClarityName::from_literal("get-next-address-id"),
                 &self.contract_principal,
                 &[],
                 None,
@@ -95,7 +95,7 @@ impl DepositAddressRegistry {
             clarity::vm::types::TypeSignature::UIntType,
             GET_ADDRESSES_MAX_IDS,
         )
-        .map_err(|e| Error::ClarityBadList(Box::new(clarity::vm::errors::Error::Unchecked(e))))?;
+        .map_err(|e| Error::ClarityBadList(Box::new(e)))?;
 
         let list = Value::list_with_type(
             &clarity::types::StacksEpochId::latest(),
@@ -110,7 +110,7 @@ impl DepositAddressRegistry {
             .call_read(
                 &self.contract_principal,
                 &self.contract_name,
-                &ClarityName::from("get-addresses"),
+                &ClarityName::from_literal("get-addresses"),
                 &self.contract_principal,
                 &arguments,
                 None,
@@ -193,11 +193,11 @@ mod tests {
         fn from(value: &RawRegisteredDepositScripts) -> Self {
             let tuple_entries = vec![
                 (
-                    ClarityName::from("deposit-script"),
+                    ClarityName::from_literal("deposit-script"),
                     Value::buff_from(value.deposit_script.clone()).unwrap(),
                 ),
                 (
-                    ClarityName::from("reclaim-script"),
+                    ClarityName::from_literal("reclaim-script"),
                     Value::buff_from(value.reclaim_script.clone()).unwrap(),
                 ),
             ];
@@ -212,9 +212,12 @@ mod tests {
                 .as_ref()
                 .map(|scripts| Box::new(scripts.into()));
             let tuple_entries = vec![
-                (ClarityName::from("id"), Value::UInt(value.id as u128)),
                 (
-                    ClarityName::from("address"),
+                    ClarityName::from_literal("id"),
+                    Value::UInt(value.id as u128),
+                ),
+                (
+                    ClarityName::from_literal("address"),
                     Value::Optional(OptionalData { data: address }),
                 ),
             ];
@@ -271,8 +274,10 @@ mod tests {
             source: MonitoredDepositSource::Registry(123),
             deposit_script_inputs: DepositScriptInputs {
                 signers_public_key,
-                recipient: PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9")
-                    .unwrap(),
+                recipient: crate::storage::model::as_principal_data(
+                    &PrincipalData::parse("ST2FQWJMF9CGPW34ZWK8FEPNK072NEV1VKRNBBMJ9").unwrap(),
+                )
+                .unwrap(),
                 max_fee: 456,
             },
             reclaim_script_inputs: ReclaimScriptInputs::try_new(

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -238,7 +238,7 @@ mod tests {
         // Setup our mock server
         let mut stacks_node_server = mockito::Server::new_async().await;
         let mock = stacks_node_server
-            .mock("POST", "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/registry/get-next-address-id?tip=latest")
+            .mock("POST", "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/registry/get-next-address-id?tip=latest")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(&raw_json_response)
@@ -340,7 +340,7 @@ mod tests {
         .unwrap();
 
         let mock = stacks_node_server
-            .mock("POST", "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/registry/get-addresses?tip=latest")
+            .mock("POST", "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/registry/get-addresses?tip=latest")
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [serialized_request_ids]
             })))

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -247,7 +247,7 @@ mod tests {
 
         // Setup our Stacks client
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         // Setup our registry
         let registry = DepositAddressRegistry::new(
@@ -352,7 +352,7 @@ mod tests {
 
         // Setup our Stacks client
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         // Setup our registry
         let registry = DepositAddressRegistry::new(

--- a/src/stacks/registry.rs
+++ b/src/stacks/registry.rs
@@ -247,7 +247,7 @@ mod tests {
 
         // Setup our Stacks client
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         // Setup our registry
         let registry = DepositAddressRegistry::new(
@@ -352,7 +352,7 @@ mod tests {
 
         // Setup our Stacks client
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         // Setup our registry
         let registry = DepositAddressRegistry::new(

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -39,8 +39,14 @@ pub const MAX_STAKERS_LENGTH: usize = 100;
 /// than 500 bytes. We also exercised this code in the contract-call tests.
 static TUPLE_WITHDRAWAL_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
     TupleTypeSignature::try_from(BTreeMap::from([
-        (ClarityName::from("staker"), TypeSignature::PrincipalType),
-        (ClarityName::from("request-id"), TypeSignature::UIntType),
+        (
+            ClarityName::from_literal("staker"),
+            TypeSignature::PrincipalType,
+        ),
+        (
+            ClarityName::from_literal("request-id"),
+            TypeSignature::UIntType,
+        ),
     ]))
     .unwrap()
 });
@@ -51,12 +57,18 @@ static TUPLE_WITHDRAWAL_ITEM_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock:
 /// the docstring for [`TUPLE_WITHDRAWAL_ITEM_SIGNATURE`].
 static TUPLE_WITHDRAWAL_KEY_SIGNATURE: LazyLock<TupleTypeSignature> = LazyLock::new(|| {
     TupleTypeSignature::try_from(BTreeMap::from([
-        (ClarityName::from("staker"), TypeSignature::PrincipalType),
         (
-            ClarityName::from("signer-manager"),
+            ClarityName::from_literal("staker"),
             TypeSignature::PrincipalType,
         ),
-        (ClarityName::from("request-id"), TypeSignature::UIntType),
+        (
+            ClarityName::from_literal("signer-manager"),
+            TypeSignature::PrincipalType,
+        ),
+        (
+            ClarityName::from_literal("request-id"),
+            TypeSignature::UIntType,
+        ),
     ]))
     .unwrap()
 });
@@ -135,13 +147,16 @@ impl WithdrawalKey {
     /// Build a withdrawal cursor tuple from its fields.
     pub fn new(staker: PrincipalData, signer_manager: PrincipalData, request_id: u128) -> Self {
         let data_map = BTreeMap::from([
-            (ClarityName::from("staker"), ClarityValue::Principal(staker)),
             (
-                ClarityName::from("signer-manager"),
+                ClarityName::from_literal("staker"),
+                ClarityValue::Principal(staker),
+            ),
+            (
+                ClarityName::from_literal("signer-manager"),
                 ClarityValue::Principal(signer_manager),
             ),
             (
-                ClarityName::from("request-id"),
+                ClarityName::from_literal("request-id"),
                 ClarityValue::UInt(request_id),
             ),
         ]);
@@ -164,9 +179,12 @@ impl WithdrawalItem {
     /// Build a withdrawal item from its fields.
     pub fn new(staker: PrincipalData, request_id: u128) -> Self {
         let data_map = BTreeMap::from([
-            (ClarityName::from("staker"), ClarityValue::Principal(staker)),
             (
-                ClarityName::from("request-id"),
+                ClarityName::from_literal("staker"),
+                ClarityValue::Principal(staker),
+            ),
+            (
+                ClarityName::from_literal("request-id"),
                 ClarityValue::UInt(request_id),
             ),
         ]);
@@ -401,11 +419,11 @@ impl RewardClaimRegistry {
             Some(key) => {
                 let tuple = TupleData::from_data(vec![
                     (
-                        ClarityName::from("staker"),
+                        ClarityName::from_literal("staker"),
                         ClarityValue::Principal(key.staker.clone()),
                     ),
                     (
-                        ClarityName::from("signer-manager"),
+                        ClarityName::from_literal("signer-manager"),
                         ClarityValue::Principal(key.signer_manager.clone()),
                     ),
                 ])
@@ -421,7 +439,7 @@ impl RewardClaimRegistry {
             .call_read(
                 &self.deployer,
                 &self.contract_name,
-                &ClarityName::from("get-pending-claims"),
+                &ClarityName::from_literal("get-pending-claims"),
                 &self.deployer,
                 &[cursor_arg],
                 chain_tip,
@@ -487,7 +505,7 @@ impl RewardClaimRegistry {
             .call_read(
                 &self.deployer,
                 &self.contract_name,
-                &ClarityName::from("get-pending-withdrawals"),
+                &ClarityName::from_literal("get-pending-withdrawals"),
                 &self.deployer,
                 &[cursor_arg],
                 chain_tip,
@@ -729,19 +747,19 @@ mod tests {
                 .map(|index| Box::new(ClarityValue::UInt(index)));
             let tuple_entries = vec![
                 (
-                    ClarityName::from("signer-manager"),
+                    ClarityName::from_literal("signer-manager"),
                     ClarityValue::Principal(PrincipalData::Contract(value.signer_manager.clone())),
                 ),
                 (
-                    ClarityName::from("staker"),
+                    ClarityName::from_literal("staker"),
                     ClarityValue::Principal(value.staker.clone()),
                 ),
                 (
-                    ClarityName::from("bond-index"),
+                    ClarityName::from_literal("bond-index"),
                     ClarityValue::Optional(OptionalData { data: bond_index }),
                 ),
                 (
-                    ClarityName::from("reward-cycle"),
+                    ClarityName::from_literal("reward-cycle"),
                     ClarityValue::UInt(value.reward_cycle),
                 ),
             ];
@@ -753,11 +771,11 @@ mod tests {
         fn from(value: &RegistrationKey) -> Self {
             let tuple_entries = vec![
                 (
-                    ClarityName::from("staker"),
+                    ClarityName::from_literal("staker"),
                     ClarityValue::Principal(value.staker.clone()),
                 ),
                 (
-                    ClarityName::from("signer-manager"),
+                    ClarityName::from_literal("signer-manager"),
                     ClarityValue::Principal(value.signer_manager.clone()),
                 ),
             ];
@@ -769,15 +787,15 @@ mod tests {
         fn from(value: &PendingWithdrawal) -> Self {
             let tuple_entries = vec![
                 (
-                    ClarityName::from("signer-manager"),
+                    ClarityName::from_literal("signer-manager"),
                     ClarityValue::Principal(PrincipalData::Contract(value.signer_manager.clone())),
                 ),
                 (
-                    ClarityName::from("staker"),
+                    ClarityName::from_literal("staker"),
                     ClarityValue::Principal(value.item.staker().clone()),
                 ),
                 (
-                    ClarityName::from("request-id"),
+                    ClarityName::from_literal("request-id"),
                     ClarityValue::UInt(value.item.request_id()),
                 ),
             ];
@@ -800,10 +818,10 @@ mod tests {
         let page = ClarityValue::Tuple(
             TupleData::from_data(vec![
                 (
-                    ClarityName::from("rows"),
+                    ClarityName::from_literal("rows"),
                     ClarityValue::cons_list_unsanitized(rows).unwrap(),
                 ),
-                (ClarityName::from("next"), next_value),
+                (ClarityName::from_literal("next"), next_value),
             ])
             .unwrap(),
         );
@@ -822,10 +840,10 @@ mod tests {
         let page = ClarityValue::Tuple(
             TupleData::from_data(vec![
                 (
-                    ClarityName::from("rows"),
+                    ClarityName::from_literal("rows"),
                     ClarityValue::cons_list_unsanitized(rows).unwrap(),
                 ),
-                (ClarityName::from("next"), next_value),
+                (ClarityName::from_literal("next"), next_value),
             ])
             .unwrap(),
         );

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -902,7 +902,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -970,7 +970,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1015,7 +1015,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1112,7 +1112,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1336,7 +1336,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1399,7 +1399,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1442,7 +1442,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1547,7 +1547,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url, None).unwrap();
+        let client = StacksClient::new(client_url, "").unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -890,7 +890,7 @@ mod tests {
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
+                "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
             )
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [ClarityValue::none().serialize_to_hex().unwrap()]
@@ -958,7 +958,7 @@ mod tests {
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
+                "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
             )
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [cursor_hex]
@@ -1006,7 +1006,7 @@ mod tests {
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
+                "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip=latest",
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1078,7 +1078,7 @@ mod tests {
             .create();
 
         let path = format!(
-            "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip={tip}"
+            "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-claims?tip={tip}"
         );
 
         let empty_with_next = stacks_node_server
@@ -1322,7 +1322,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let path = "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest";
+        let path = "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest";
         let mut stacks_node_server = mockito::Server::new_async().await;
         let mock = stacks_node_server
             .mock("POST", path)
@@ -1387,7 +1387,7 @@ mod tests {
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest",
+                "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest",
             )
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "arguments": [cursor_hex]
@@ -1433,7 +1433,7 @@ mod tests {
         let mock = stacks_node_server
             .mock(
                 "POST",
-                "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest",
+                "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip=latest",
             )
             .with_status(200)
             .with_header("content-type", "application/json")
@@ -1511,7 +1511,7 @@ mod tests {
             .create();
 
         let path = format!(
-            "/v2/contracts/call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip={tip}"
+            "/v3/contracts/fast-call-read/ST2SBXRBJJTH7GV5J93HJ62W2NRRQ46XYBK92Y039/reward-claim-registry/get-pending-withdrawals?tip={tip}"
         );
 
         let empty_with_next = stacks_node_server

--- a/src/stacks/reward_claim_registry.rs
+++ b/src/stacks/reward_claim_registry.rs
@@ -902,7 +902,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -970,7 +970,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1015,7 +1015,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1112,7 +1112,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1336,7 +1336,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1399,7 +1399,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1442,7 +1442,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(
@@ -1547,7 +1547,7 @@ mod tests {
             .create();
 
         let client_url = url::Url::parse(stacks_node_server.url().as_str()).unwrap();
-        let client = StacksClient::new(client_url).unwrap();
+        let client = StacksClient::new(client_url, None).unwrap();
 
         let registry = RewardClaimRegistry::new(
             QualifiedContractIdentifier::parse(

--- a/src/stacks/transaction.rs
+++ b/src/stacks/transaction.rs
@@ -19,18 +19,18 @@ const REWARD_CLAIM_TRAIT_CONTRACT: &str = "reward-claim-traits";
 
 /// This function creates a Trait identifier for the
 /// [`REWARD_CLAIM_TRAIT_NAME`] trait, once we know the issuer/deployer.
-pub fn make_trait_identifier(deployer: StacksAddress) -> TraitIdentifier {
-    TraitIdentifier {
-        name: ClarityName::from(REWARD_CLAIM_TRAIT_NAME),
+pub fn make_trait_identifier(deployer: StacksAddress) -> Box<TraitIdentifier> {
+    Box::new(TraitIdentifier {
+        name: ClarityName::from_literal(REWARD_CLAIM_TRAIT_NAME),
         contract_identifier: QualifiedContractIdentifier {
             issuer: StandardPrincipalData::from(deployer),
-            // The following From::from call is more dangerous than it
-            // appears. Under the hood it calls its TryFrom::try_from
-            // implementation and then unwrap them. We check that this
-            // is fine in our test.
-            name: ContractName::from(REWARD_CLAIM_TRAIT_CONTRACT),
+            // The ContractName::from_literal call is more dangerous than
+            // it appears. Under the hood it calls its TryFrom::try_from
+            // implementation and then unwrap them. We check that this is
+            // fine in our test.
+            name: ContractName::from_literal(REWARD_CLAIM_TRAIT_CONTRACT),
         },
-    }
+    })
 }
 
 /// A trait to ease construction of a contract call StacksTransaction.
@@ -47,12 +47,12 @@ pub trait IntoContractCall: Sized {
     fn into_tx_payload(self) -> TransactionPayload {
         let contract_call = TransactionContractCall {
             address: self.deployer_address().clone(),
-            // The following From::from calls are more dangerous than they
-            // appear. Under the hood they call their TryFrom::try_from
-            // implementation and then unwrap them(!). We check that this
-            // is fine in our test.
-            function_name: ClarityName::from(Self::FUNCTION_NAME),
-            contract_name: ContractName::from(Self::CONTRACT_NAME),
+            // The ContractName::from_literal call is more dangerous than
+            // it appears. Under the hood it calls its TryFrom::try_from
+            // implementation and then unwrap them. We check that this is
+            // fine in our test.
+            function_name: ClarityName::from_literal(Self::FUNCTION_NAME),
+            contract_name: ContractName::from_literal(Self::CONTRACT_NAME),
             function_args: self.into_contract_args(),
         };
         TransactionPayload::ContractCall(contract_call)

--- a/src/stacks/wallet.rs
+++ b/src/stacks/wallet.rs
@@ -114,7 +114,9 @@ impl StacksWallet {
             chain_id: self.chain_id,
             auth: TransactionAuth::Standard(Singlesig(auth)),
             anchor_mode: TransactionAnchorMode::Any,
-            post_condition_mode: TransactionPostConditionMode::Deny,
+            // Uses originator post-condition mode to deny asset movement for our
+            // assets allow it for all other principals.
+            post_condition_mode: TransactionPostConditionMode::Originator,
             post_conditions: Vec::new(),
             payload,
         };
@@ -188,6 +190,7 @@ impl RecoverableEcdsaSignature for RecoverableSignature {
 #[cfg(test)]
 mod tests {
     use blockstack_lib::chainstate::stacks::TokenTransferMemo;
+    use blockstack_lib::chainstate::stacks::TransactionAuthVerificationMode;
     use blockstack_lib::chainstate::stacks::TransactionPayload;
     use blockstack_lib::core::CHAIN_ID_TESTNET;
     use clarity::types::chainstate::StacksAddress;
@@ -226,12 +229,18 @@ mod tests {
 
     #[test]
     fn sign_tx_produces_verifiable_transaction() {
+        use TransactionAuthVerificationMode::EnforceLowS;
         let wallet = StacksWallet::new(test_secret_key(), CHAIN_ID_TESTNET, 0);
         let payload = token_transfer_payload(wallet.address());
 
         let tx = wallet.sign_tx(payload, 1000);
-        assert!(tx.verify().is_ok());
+        assert!(tx.verify(EnforceLowS).is_ok());
         assert_eq!(tx.chain_id, CHAIN_ID_TESTNET);
+        assert_eq!(
+            tx.post_condition_mode,
+            TransactionPostConditionMode::Originator
+        );
+        assert!(tx.post_conditions.is_empty());
         assert_eq!(wallet.nonce(), 0);
     }
 

--- a/src/storage/model.rs
+++ b/src/storage/model.rs
@@ -1,7 +1,9 @@
 //! Data models used in spox.
 
 use bitcoin::ScriptBuf;
+use clarity::vm::types::PrincipalData;
 use sbtc::deposits::{DepositScriptInputs, ReclaimScriptInputs};
+use serde::de::DeserializeOwned;
 
 use crate::{config::MonitoredDepositConfig, error::Error};
 
@@ -35,6 +37,15 @@ impl MonitoredDeposit {
     }
 }
 
+/// Convert a principal into the type expected by the sbtc crate.
+pub fn as_principal_data<T>(principal: &PrincipalData) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+{
+    let value = serde_json::to_value(principal).map_err(Error::PrincipalDataSerdeJson)?;
+    serde_json::from_value(value).map_err(Error::PrincipalDataSerdeJson)
+}
+
 impl TryFrom<(&String, &MonitoredDepositConfig)> for MonitoredDeposit {
     type Error = Error;
 
@@ -44,7 +55,7 @@ impl TryFrom<(&String, &MonitoredDepositConfig)> for MonitoredDeposit {
             source: MonitoredDepositSource::Config(alias.clone()),
             deposit_script_inputs: DepositScriptInputs {
                 signers_public_key: deposit.signers_xonly,
-                recipient: deposit.recipient,
+                recipient: as_principal_data(&deposit.recipient)?,
                 max_fee: deposit.max_fee,
             },
             reclaim_script_inputs: ReclaimScriptInputs::try_new(


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/72.

## Changes

* Bump the version of stacks core to the one that has originator post-conditions.
* Use originator post-conditions for all transactions.
* Add an `auth_token` config parameter for gated RPC calls to the Stacks node. Use it in all requests to the Stacks node.

## Testing Information

Added some unit tests. ~I'll do some "full" integration tests later~ I did a full local integration test, and everything was fine.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
