### PR TITLE
feat: allow for batched registrations

### DIFF
--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -1,6 +1,6 @@
 # Reward Claim Registry
 
-Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims`; the caller is stored as `registrant`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
+Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims` or `register-many-for-claims`; the caller is stored as `registrant`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
 
 ## Invariants
 
@@ -11,14 +11,15 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - **Always advance.** A failed `claim-rewards` or `claim-staker-rewards` still decrements `remaining-claims`, burns one installment from escrow, and advances the schedule. A junk or already-settled `withdrawal-request` is not stored and does not stall the claim.
 - **Self-heal pull.** If a signer manager has earned rewards in pox-5 for the reward cycle, the registry calls `claim-rewards` before `claim-staker-rewards`.
 - **Escrow then burn.** Fees are held as `prepaid-ustx` and burned one installment at a time when a claim is made. Admins do not need to escrow funds.
-- **Anyone may register.** `register-for-claims` has no caller restriction beyond a live pox-5 position under that signer-manager. `contract-caller` is stored as `payer`.
-- **One payer per registration.** Only that `payer` may `add-claims`. Cancel is the staker or the payer; remaining `prepaid-ustx` is refunded to the payer.
+- **Anyone may register.** `register-for-claims` and `register-many-for-claims` have no caller restriction beyond live pox-5 positions under that signer-manager. `contract-caller` is stored as `registrant`.
+- **One registrant per registration.** Only that `registrant` may `add-claims`. Cancel is the staker or the registrant; remaining `prepaid-ustx` is refunded to the registrant.
 - **add-claims preserves schedule.** Buying more installments for `{staker, signer-manager}` only increases `remaining-claims` and `prepaid-ustx`. Re-registering the same key fails with `ERR_ALREADY_REGISTERED`.
+- **Batch registration is best-effort.** Failed entries are skipped without aborting the batch.
 
 ## Gotchas
 
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
-- The staker or the payer may `cancel-registration`. Remaining `prepaid-ustx` is refunded to the payer, not necessarily the staker. Pending L1 withdrawals remain settleable.
+- The staker or the registrant may `cancel-registration`. Remaining `prepaid-ustx` is refunded to the registrant, not necessarily the staker. Pending L1 withdrawals remain settleable.
 - Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-withdrawals` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
 - `get-pending-claims` and `get-pending-withdrawals` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.

--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -1,6 +1,6 @@
 # Reward Claim Registry
 
-Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims` or `register-many-for-claims`; the caller is stored as `registrant`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
+Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims` or `register-many-for-claims`; the caller is stored as `sponsor`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
 
 ## Invariants
 
@@ -11,8 +11,8 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - **Always advance.** A failed `claim-rewards` or `claim-staker-rewards` still decrements `remaining-claims`, burns one installment from escrow, and advances the schedule. A junk or already-settled `withdrawal-request` is not stored and does not stall the claim.
 - **Self-heal pull.** If a signer manager has earned rewards in pox-5 for the reward cycle, the registry calls `claim-rewards` before `claim-staker-rewards`.
 - **Escrow then burn.** Fees are held as `prepaid-ustx` and burned one installment at a time when a claim is made. Admins do not need to escrow funds.
-- **Anyone may register.** `register-for-claims` and `register-many-for-claims` have no caller restriction beyond live pox-5 positions under that signer-manager. `contract-caller` is stored as `registrant`.
-- **One registrant per registration.** Only that `registrant` may `add-claims`. Cancel is the staker or the registrant; remaining `prepaid-ustx` is refunded to the registrant.
+- **Anyone may register.** `register-for-claims` and `register-many-for-claims` have no caller restriction beyond live pox-5 positions under that signer-manager. `contract-caller` is stored as `sponsor`.
+- **One sponsor per registration.** Only that `sponsor` may `add-claims`. Cancel is the staker or the sponsor; remaining `prepaid-ustx` is refunded to the sponsor.
 - **add-claims preserves schedule.** Buying more installments for `{staker, signer-manager}` only increases `remaining-claims` and `prepaid-ustx`. Re-registering the same key fails with `ERR_ALREADY_REGISTERED`.
 - **Batch registration is best-effort.** Failed entries are skipped without aborting the batch.
 
@@ -20,6 +20,6 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
-- The staker or the registrant may `cancel-registration`. Remaining `prepaid-ustx` is refunded to the registrant, not necessarily the staker. Pending L1 withdrawals remain settleable.
+- The staker or the sponsor may `cancel-registration`. Remaining `prepaid-ustx` is refunded to the sponsor, not necessarily the staker. Pending L1 withdrawals remain settleable.
 - Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-withdrawals` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
 - `get-pending-claims` and `get-pending-withdrawals` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.

--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -1,6 +1,6 @@
 # Reward Claim Registry
 
-Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. A staker (or an admin on their behalf) buys claim installments by escrowing STX, choosing a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
+Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims`; the caller is stored as `registrant`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
 
 ## Invariants
 
@@ -11,13 +11,14 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - **Always advance.** A failed `claim-rewards` or `claim-staker-rewards` still decrements `remaining-claims`, burns one installment from escrow, and advances the schedule. A junk or already-settled `withdrawal-request` is not stored and does not stall the claim.
 - **Self-heal pull.** If a signer manager has earned rewards in pox-5 for the reward cycle, the registry calls `claim-rewards` before `claim-staker-rewards`.
 - **Escrow then burn.** Fees are held as `prepaid-ustx` and burned one installment at a time when a claim is made. Admins do not need to escrow funds.
-- **Self-register (or admin).** Only the staker or an admin may `register-for-claims` / `add-claims`. Cancel is staker-only, including when an admin created the registration; remaining escrow is refunded to the staker.
+- **Anyone may register.** `register-for-claims` has no caller restriction beyond a live pox-5 position under that signer-manager. `contract-caller` is stored as `payer`.
+- **One payer per registration.** Only that `payer` may `add-claims`. Cancel is the staker or the payer; remaining `prepaid-ustx` is refunded to the payer.
 - **add-claims preserves schedule.** Buying more installments for `{staker, signer-manager}` only increases `remaining-claims` and `prepaid-ustx`. Re-registering the same key fails with `ERR_ALREADY_REGISTERED`.
 
 ## Gotchas
 
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
-- Only the staker may `cancel-registration` (admins cannot cancel for them). Remaining `prepaid-ustx` is refunded to the staker; pending L1 withdrawals remain settleable.
+- The staker or the payer may `cancel-registration`. Remaining `prepaid-ustx` is refunded to the payer, not necessarily the staker. Pending L1 withdrawals remain settleable.
 - Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-withdrawals` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
 - `get-pending-claims` and `get-pending-withdrawals` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.

--- a/contracts/contracts/reward-claim-registry.README.md
+++ b/contracts/contracts/reward-claim-registry.README.md
@@ -1,6 +1,6 @@
 # Reward Claim Registry
 
-Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims` or `register-many-for-claims`; the caller is stored as `sponsor`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
+Permissionless keeper contract that registers PoX-5 stakers for automated reward claims via their signer-manager. Anyone (the staker, a pool operator, or an admin) may `register-for-claims` or `register-many-for-claims`; `tx-sender` is stored as `sponsor`. They choose a `start-reward-cycle` and whether to claim at most once or twice per reward cycle (`one-claim-per-reward-cycle`). spox later calls `process-reward-claim(s)` to pull rewards from pox-5 when needed, claim for the staker, and advance the schedule. Each advance burns one installment from escrow. L1 sBTC withdrawals are tracked and settled separately.
 
 ## Invariants
 
@@ -11,15 +11,15 @@ Permissionless keeper contract that registers PoX-5 stakers for automated reward
 - **Always advance.** A failed `claim-rewards` or `claim-staker-rewards` still decrements `remaining-claims`, burns one installment from escrow, and advances the schedule. A junk or already-settled `withdrawal-request` is not stored and does not stall the claim.
 - **Self-heal pull.** If a signer manager has earned rewards in pox-5 for the reward cycle, the registry calls `claim-rewards` before `claim-staker-rewards`.
 - **Escrow then burn.** Fees are held as `prepaid-ustx` and burned one installment at a time when a claim is made. Admins do not need to escrow funds.
-- **Anyone may register.** `register-for-claims` and `register-many-for-claims` have no caller restriction beyond live pox-5 positions under that signer-manager. `contract-caller` is stored as `sponsor`.
-- **One sponsor per registration.** Only that `sponsor` may `add-claims`. Cancel is the staker or the sponsor; remaining `prepaid-ustx` is refunded to the sponsor.
+- **Anyone may register.** `register-for-claims` and `register-many-for-claims` have no caller restriction beyond live pox-5 positions under that signer-manager. `tx-sender` is stored as `sponsor` (so a helper contract can batch-register while the signed origin remains the sponsor).
+- **One sponsor per registration.** Only that `sponsor` (as `tx-sender`) may `add-claims`. Cancel is the staker or the sponsor (matched as `tx-sender`); remaining `prepaid-ustx` is refunded to the sponsor.
 - **add-claims preserves schedule.** Buying more installments for `{staker, signer-manager}` only increases `remaining-claims` and `prepaid-ustx`. Re-registering the same key fails with `ERR_ALREADY_REGISTERED`.
-- **Batch registration is best-effort.** Failed entries are skipped without aborting the batch.
+- **Batch registration / cancel are best-effort.** Failed entries are skipped without aborting the batch.
 
 ## Gotchas
 
 - Registration requires a **live** pox-5 stake under that signer-manager; bond-index is looked up, not passed.
 - Empty / failed claims still burn a claim installment from escrow.
-- The staker or the sponsor may `cancel-registration`. Remaining `prepaid-ustx` is refunded to the sponsor, not necessarily the staker. Pending L1 withdrawals remain settleable.
+- The staker or the sponsor may `cancel-registration` / `cancel-many-registrations`. Remaining `prepaid-ustx` is refunded to the sponsor, not necessarily the staker. Pending L1 withdrawals remain settleable.
 - Live sBTC-pending requests are indexed one map row per `{staker, signer-manager, request-id}` regardless of who created the withdrawal. `get-pending-withdrawals` lists a row after 7 Bitcoin blocks and only if sBTC status indicates acceptance or rejection from the sbtc signer. `settle-pending-withdrawal` drops the ID once sBTC has resolved (or the request is missing), even if the signer-manager errors.
 - `get-pending-claims` and `get-pending-withdrawals` may return an empty `rows` list while `next` is still set. Paginate with `next` until it is `none`.

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -75,8 +75,8 @@
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
 ;; start-reward-cycle is before the position's first-reward-cycle
 (define-constant ERR_INVALID_START_REWARD_CYCLE (err u608))
-;; This is returned when the contract-caller is not the registrant for add-claims
-;; calls, or not the staker or registrant for cancel-registration calls.
+;; This is returned when the contract-caller is not the sponsor for add-claims
+;; calls, or not the staker or sponsor for cancel-registration calls.
 (define-constant ERR_UNAUTHORIZED (err u609))
 ;; A registration already exists for this staker and signer-manager
 (define-constant ERR_ALREADY_REGISTERED (err u610))
@@ -151,13 +151,13 @@
         next-claim-distribution: uint,
         ;; The STX held by this contract for unconsumed installments.
         ;; Burned one installment at a time per processed claim. Note that
-        ;; this amount is refunded to the registrant when the registration
+        ;; this amount is refunded to the sponsor when the registration
         ;; is cancelled.
         prepaid-ustx: uint,
         ;; The principal that created this registration and whose STX is
         ;; escrowed in prepaid-ustx. The only caller allowed to add-claims.
         ;; Cancel refunds remaining prepaid-ustx to this principal.
-        registrant: principal,
+        sponsor: principal,
     }
 )
 
@@ -170,7 +170,7 @@
 ;; Returns:
 ;;   The registration tuple if present, otherwise none. The tuple holds
 ;;   bond-index, remaining-claims, one-claim-per-reward-cycle,
-;;   next-claim-distribution, prepaid-ustx, and registrant.
+;;   next-claim-distribution, prepaid-ustx, and sponsor.
 (define-read-only (get-registration
         (staker principal)
         (signer-manager principal)
@@ -469,7 +469,7 @@
             one-claim-per-reward-cycle: bool,
             next-claim-distribution: uint,
             prepaid-ustx: uint,
-            registrant: principal,
+            sponsor: principal,
         })
         (current-distribution-cycle uint)
         (last-compute-distribution (optional uint))
@@ -681,7 +681,7 @@
                     one-claim-per-reward-cycle: bool,
                     next-claim-distribution: uint,
                     prepaid-ustx: uint,
-                    registrant: principal,
+                    sponsor: principal,
                 }
             ),
         })
@@ -780,7 +780,7 @@
 ;; --- Registration lifecycle helpers ---
 ;; register-for-claims / add-claims escrow STX and write the registration.
 ;; Advance burns one installment from escrow; cancel refunds the rest of
-;; the escrowed STX to the registrant of the registration.
+;; the escrowed STX to the sponsor of the registration.
 
 ;; Escrow the STX fee for the given number of claim installments unless
 ;; contract-caller is an admin. Returns the micro-STX amount escrowed.
@@ -832,13 +832,13 @@
                 one-claim-per-reward-cycle: one-claim-per-reward-cycle,
                 next-claim-distribution: (initial-next-claim-distribution start-reward-cycle one-claim-per-reward-cycle),
                 prepaid-ustx: escrowed,
-                registrant: contract-caller,
+                sponsor: contract-caller,
             })
             (ll-append key)
             (print {
                 topic: "register-for-claims",
                 staker: staker,
-                registrant: contract-caller,
+                sponsor: contract-caller,
                 signer-manager: signer-manager,
                 start-reward-cycle: start-reward-cycle,
                 one-claim-per-reward-cycle: one-claim-per-reward-cycle,
@@ -885,7 +885,7 @@
 )
 
 ;; Register a staker for automated reward claims. Anyone may call this;
-;; contract-caller is stored as `registrant` and is the only principal that may
+;; contract-caller is stored as `sponsor` and is the only principal that may
 ;; add-claims. Admins pay no fee. The staker must currently be staking in
 ;; pox-5. The active bond-index, if any, is looked up from pox-5; callers do
 ;; not pass it. Schedule seeds next-claim-distribution from start-reward-cycle.
@@ -960,8 +960,8 @@
 )
 
 ;; Buy additional claim installments for an existing registration. Only the
-;; stored registrant may call this. Does not change next-claim-distribution,
-;; one-claim-per-reward-cycle, bond-index, or registrant. Fee STX is escrowed
+;; stored sponsor may call this. Does not change next-claim-distribution,
+;; one-claim-per-reward-cycle, bond-index, or sponsor. Fee STX is escrowed
 ;; and burned later when a claim is processed.
 ;;
 ;; Parameters:
@@ -974,7 +974,7 @@
 ;;
 ;; Returns:
 ;;   ok with the number of claim installments added on this call, or an error
-;;   if the caller is not the registrant, fee buys no claims, or no registration
+;;   if the caller is not the sponsor, fee buys no claims, or no registration
 ;;   exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
@@ -992,9 +992,9 @@
             })
         )
         (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
-        ;; Fail before escrowing if this key is not registered or caller is not the registrant.
+        ;; Fail before escrowing if this key is not registered or caller is not the sponsor.
         (let ((existing (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED)))
-            (asserts! (is-eq contract-caller (get registrant existing)) ERR_UNAUTHORIZED)
+            (asserts! (is-eq contract-caller (get sponsor existing)) ERR_UNAUTHORIZED)
             (let ((escrowed (try! (escrow-registration-fee num-claims))))
                 (map-set registrations key
                     (merge existing {
@@ -1005,7 +1005,7 @@
                 (print {
                     topic: "add-claims",
                     staker: staker,
-                    registrant: contract-caller,
+                    sponsor: contract-caller,
                     signer-manager: signer-manager,
                     num-claims: num-claims,
                     escrowed: escrowed,
@@ -1016,9 +1016,9 @@
     )
 )
 
-;; Cancel a registration. The staker or the stored registrant may call this.
+;; Cancel a registration. The staker or the stored sponsor may call this.
 ;; Deletes the registration map entry and removes it from the registration
-;; linked list. Refunds any remaining prepaid-ustx to the registrant. Does not
+;; linked list. Refunds any remaining prepaid-ustx to the sponsor. Does not
 ;; touch pending L1 withdrawals for this key; those remain settleable via
 ;; settle-pending-withdrawal.
 ;;
@@ -1027,8 +1027,8 @@
 ;;   signer-manager  The signer-manager principal on the registration key.
 ;;
 ;; Returns:
-;;   ok with the micro-STX refunded to the registrant, ERR_UNAUTHORIZED
-;;   if contract-caller is neither the staker nor the registrant, or
+;;   ok with the micro-STX refunded to the sponsor, ERR_UNAUTHORIZED
+;;   if contract-caller is neither the staker nor the sponsor, or
 ;;   ERR_NOT_REGISTERED if no registration exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
@@ -1046,9 +1046,9 @@
                 })
                 (registration (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
                 (refund (get prepaid-ustx registration))
-                (registrant (get registrant registration))
+                (sponsor (get sponsor registration))
             )
-            (asserts! (or (is-eq contract-caller staker) (is-eq contract-caller registrant))
+            (asserts! (or (is-eq contract-caller staker) (is-eq contract-caller sponsor))
                 ERR_UNAUTHORIZED
             )
             (map-delete registrations key)
@@ -1056,14 +1056,14 @@
             (begin
                 (if (> refund u0)
                     (try! (as-contract? ((with-stx refund))
-                        (try! (stx-transfer? refund tx-sender registrant))
+                        (try! (stx-transfer? refund tx-sender sponsor))
                     ))
                     true
                 )
                 (print {
                     topic: "cancel-registration",
                     staker: staker,
-                    registrant: registrant,
+                    sponsor: sponsor,
                     signer-manager: signer-manager,
                     refund: refund,
                 })
@@ -1090,7 +1090,7 @@
             one-claim-per-reward-cycle: bool,
             next-claim-distribution: uint,
             prepaid-ustx: uint,
-            registrant: principal,
+            sponsor: principal,
         })
         (current-distribution-cycle uint)
     )
@@ -1227,7 +1227,7 @@
             one-claim-per-reward-cycle: bool,
             next-claim-distribution: uint,
             prepaid-ustx: uint,
-            registrant: principal,
+            sponsor: principal,
         })
         (reward-cycle uint)
         (claim-distribution uint)

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -75,8 +75,8 @@
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
 ;; start-reward-cycle is before the position's first-reward-cycle
 (define-constant ERR_INVALID_START_REWARD_CYCLE (err u608))
-;; This is returned when the contract-caller is not allowed to register,
-;; add claims, or cancel for this staker.
+;; This is returned when the contract-caller is not the registrant for add-claims
+;; calls, or not the staker or registrant for cancel-registration calls.
 (define-constant ERR_UNAUTHORIZED (err u609))
 ;; A registration already exists for this staker and signer-manager
 (define-constant ERR_ALREADY_REGISTERED (err u610))
@@ -151,8 +151,13 @@
         next-claim-distribution: uint,
         ;; The STX held by this contract for unconsumed installments.
         ;; Burned one installment at a time per processed claim. Note that
-        ;; this amount is refunded to the staker when they cancel.
+        ;; this amount is refunded to the registrant when the registration
+        ;; is cancelled.
         prepaid-ustx: uint,
+        ;; The principal that created this registration and whose STX is
+        ;; escrowed in prepaid-ustx. The only caller allowed to add-claims.
+        ;; Cancel refunds remaining prepaid-ustx to this principal.
+        registrant: principal,
     }
 )
 
@@ -165,7 +170,7 @@
 ;; Returns:
 ;;   The registration tuple if present, otherwise none. The tuple holds
 ;;   bond-index, remaining-claims, one-claim-per-reward-cycle,
-;;   next-claim-distribution, and prepaid-ustx.
+;;   next-claim-distribution, prepaid-ustx, and payer.
 (define-read-only (get-registration
         (staker principal)
         (signer-manager principal)
@@ -464,6 +469,7 @@
             one-claim-per-reward-cycle: bool,
             next-claim-distribution: uint,
             prepaid-ustx: uint,
+            registrant: principal,
         })
         (current-distribution-cycle uint)
         (last-compute-distribution (optional uint))
@@ -675,6 +681,7 @@
                     one-claim-per-reward-cycle: bool,
                     next-claim-distribution: uint,
                     prepaid-ustx: uint,
+                    registrant: principal,
                 }
             ),
         })
@@ -772,13 +779,8 @@
 
 ;; --- Registration lifecycle helpers ---
 ;; register-for-claims / add-claims escrow STX and write the registration.
-;; Advance burns one installment from escrow; cancel refunds the rest.
-
-;; Staker may act on their own registration; admins may register or top up
-;; anyone. Cancel stays staker-only (see cancel-registration).
-(define-private (authorize-staker-or-admin (staker principal))
-    (ok (asserts! (or (is-eq contract-caller staker) (is-admin contract-caller)) ERR_UNAUTHORIZED))
-)
+;; Advance burns one installment from escrow; cancel refunds the rest of
+;; the escrowed STX to the payer of the registration.
 
 ;; Escrow the STX fee for the given number of claim installments unless
 ;; contract-caller is an admin. Returns the micro-STX amount escrowed.
@@ -798,8 +800,9 @@
     )
 )
 
-;; Register a staker for automated reward claims. Only the staker or an admin
-;; may call this. Admins pay no fee. The staker must currently be staking in
+;; Register a staker for automated reward claims. Anyone may call this;
+;; contract-caller is stored as `registrant` and is the only principal that may
+;; add-claims. Admins pay no fee. The staker must currently be staking in
 ;; pox-5. The active bond-index, if any, is looked up from pox-5; callers do
 ;; not pass it. Schedule seeds next-claim-distribution from start-reward-cycle.
 ;; Fee STX is escrowed in this contract and burned one installment at a time
@@ -807,8 +810,7 @@
 ;; registered; use add-claims to buy more installments.
 ;;
 ;; Parameters:
-;;   staker                      The principal being registered. Must equal
-;;                               contract-caller unless the caller is an admin.
+;;   staker                      The principal being registered.
 ;;   signer-manager              Together with staker forms the registration key.
 ;;                               Must be the signer pox-5 reports for the
 ;;                               position; every claim pulls from it.
@@ -828,9 +830,9 @@
 ;;
 ;; Returns:
 ;;   ok with the number of claim installments bought on this call, or an error
-;;   if the caller is unauthorized, fee buys no claims, a registration already
-;;   exists, the position is missing or under a different signer, or
-;;   start-reward-cycle is before the position's first-reward-cycle.
+;;   if fee buys no claims, a registration already exists, the position is
+;;   missing or under a different signer, or start-reward-cycle is before the
+;;   position's first-reward-cycle.
 (define-public (register-for-claims
         (staker principal)
         (signer-manager <reward-claim-signer-manager-trait>)
@@ -848,7 +850,6 @@
             })
             (position (unwrap! (get-position staker) ERR_NO_CURRENT_POSITION))
         )
-        (try! (authorize-staker-or-admin staker))
         ;; Validate before escrowing.
         (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
         (asserts! (is-none (map-get? registrations key)) ERR_ALREADY_REGISTERED)
@@ -863,6 +864,7 @@
                 one-claim-per-reward-cycle: one-claim-per-reward-cycle,
                 next-claim-distribution: (initial-next-claim-distribution start-reward-cycle one-claim-per-reward-cycle),
                 prepaid-ustx: escrowed,
+                registrant: contract-caller,
             })
             (ll-append key)
             (print {
@@ -881,13 +883,12 @@
 )
 
 ;; Buy additional claim installments for an existing registration. Only the
-;; staker or an admin may call this. Does not change next-claim-distribution,
-;; one-claim-per-reward-cycle, or bond-index. Fee STX is escrowed and burned
-;; later on advance.
+;; stored registrant may call this. Does not change next-claim-distribution,
+;; one-claim-per-reward-cycle, bond-index, or payer. Fee STX is escrowed and
+;; burned later on advance.
 ;;
 ;; Parameters:
-;;   staker          The staker on the registration key. Must equal contract-caller
-;;                   unless the caller is an admin.
+;;   staker          The staker on the registration key.
 ;;   signer-manager  The signer-manager principal on the registration key.
 ;;   fee             STX paid by contract-caller. Buys the minimum of fee divided by
 ;;                   fee-per-claim and MAX_CLAIM_INSTALLMENTS. Only the used portion
@@ -896,7 +897,7 @@
 ;;
 ;; Returns:
 ;;   ok with the number of claim installments added on this call, or an error
-;;   if the caller is unauthorized, fee buys no claims, or no registration
+;;   if the caller is not the registrant, fee buys no claims, or no registration
 ;;   exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
@@ -914,45 +915,44 @@
             })
         )
         (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
-        (try! (authorize-staker-or-admin staker))
-        ;; Fail before escrowing if this key is not registered.
-        (let (
-                (existing (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
-                (escrowed (try! (escrow-registration-fee num-claims)))
-            )
-            (map-set registrations key
-                (merge existing {
-                    remaining-claims: (+ (get remaining-claims existing) num-claims),
-                    prepaid-ustx: (+ (get prepaid-ustx existing) escrowed),
+        ;; Fail before escrowing if this key is not registered or caller is not the registrant.
+        (let ((existing (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED)))
+            (asserts! (is-eq contract-caller (get registrant existing)) ERR_UNAUTHORIZED)
+            (let ((escrowed (try! (escrow-registration-fee num-claims))))
+                (map-set registrations key
+                    (merge existing {
+                        remaining-claims: (+ (get remaining-claims existing) num-claims),
+                        prepaid-ustx: (+ (get prepaid-ustx existing) escrowed),
+                    })
+                )
+                (print {
+                    topic: "add-claims",
+                    staker: staker,
+                    registrant: contract-caller,
+                    signer-manager: signer-manager,
+                    num-claims: num-claims,
+                    escrowed: escrowed,
                 })
+                (ok num-claims)
             )
-            (print {
-                topic: "add-claims",
-                staker: staker,
-                payer: contract-caller,
-                signer-manager: signer-manager,
-                num-claims: num-claims,
-                escrowed: escrowed,
-            })
-            (ok num-claims)
         )
     )
 )
 
-;; Cancel a registration. Only the staker may call this - not an admin, even
-;; if the admin created the registration. Deletes the registration map entry
-;; and removes it from the registration linked list. Refunds any remaining
-;; prepaid-ustx to the staker. Does not touch pending L1 withdrawals for this
-;; key; those remain settleable via settle-pending-withdrawal.
+;; Cancel a registration. The staker or the stored registrant may call this.
+;; Deletes the registration map entry and removes it from the registration
+;; linked list. Refunds any remaining prepaid-ustx to the registrant. Does not
+;; touch pending L1 withdrawals for this key; those remain settleable via
+;; settle-pending-withdrawal.
 ;;
 ;; Parameters:
-;;   staker          The staker on the registration key. Must equal contract-caller.
+;;   staker          The staker on the registration key.
 ;;   signer-manager  The signer-manager principal on the registration key.
 ;;
 ;; Returns:
-;;   ok with the micro-STX refunded to the staker, ERR_UNAUTHORIZED if
-;;   contract-caller is not the staker, or ERR_NOT_REGISTERED if no registration
-;;   exists for this key.
+;;   ok with the micro-STX refunded to the registrant, ERR_UNAUTHORIZED
+;;   if contract-caller is neither the staker nor the registrant, or
+;;   ERR_NOT_REGISTERED if no registration exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
 (define-public (cancel-registration
@@ -969,18 +969,22 @@
                 })
                 (registration (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
                 (refund (get prepaid-ustx registration))
+                (registrant (get registrant registration))
             )
-            (asserts! (is-eq contract-caller staker) ERR_UNAUTHORIZED)
+            (asserts! (or (is-eq contract-caller staker) (is-eq contract-caller registrant))
+                ERR_UNAUTHORIZED
+            )
             (map-delete registrations key)
             (ll-remove key)
             (begin
                 (if (> refund u0)
-                    (try! (as-contract? ((with-stx refund)) (try! (stx-transfer? refund tx-sender staker))))
+                    (try! (as-contract? ((with-stx refund)) (try! (stx-transfer? refund tx-sender registrant))))
                     true
                 )
                 (print {
                     topic: "cancel-registration",
                     staker: staker,
+                    registrant: registrant,
                     signer-manager: signer-manager,
                     refund: refund,
                 })
@@ -1007,6 +1011,7 @@
             one-claim-per-reward-cycle: bool,
             next-claim-distribution: uint,
             prepaid-ustx: uint,
+            registrant: principal,
         })
         (current-distribution-cycle uint)
     )
@@ -1143,6 +1148,7 @@
             one-claim-per-reward-cycle: bool,
             next-claim-distribution: uint,
             prepaid-ustx: uint,
+            registrant: principal,
         })
         (reward-cycle uint)
         (claim-distribution uint)

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -459,9 +459,9 @@
     )
 )
 
-;; Returns true if this registration has remaining cycles left, its next claim
-;; distribution is strictly before the current distribution cycle, and
-;; calculate-rewards has covered that claim distribution.
+;; Returns true if this registration's next claim distribution is strictly
+;; before the current distribution cycle, and calculate-rewards has covered
+;; that claim distribution.
 (define-private (is-pending
         (registration {
             remaining-claims: uint,
@@ -475,7 +475,6 @@
         (last-compute-distribution (optional uint))
     )
     (and
-        (> (get remaining-claims registration) u0)
         (< (get next-claim-distribution registration) current-distribution-cycle)
         (rewards-calculated-for-claim-distribution (get next-claim-distribution registration)
             last-compute-distribution
@@ -853,7 +852,7 @@
 ;; Fold step for register-many-for-claims: match each register-for-claims-impl
 ;; result so a skip or failure doesn't abort the batch. Prints a skip event on
 ;; failure. Returns the count in the accumulator's registered field.
-(define-private (count-registations
+(define-private (count-registrations
         (entry {
             staker: principal,
             start-reward-cycle: uint,
@@ -924,8 +923,12 @@
         (one-claim-per-reward-cycle bool)
         (fee uint)
     )
-    (register-for-claims-impl staker (contract-of signer-manager) start-reward-cycle
-        one-claim-per-reward-cycle fee
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (register-for-claims-impl staker (contract-of signer-manager) start-reward-cycle
+            one-claim-per-reward-cycle fee
+        )
     )
 )
 
@@ -942,7 +945,7 @@
 ;;   returned ok.
 (define-public (register-many-for-claims
         (signer-manager <reward-claim-signer-manager-trait>)
-        (stakers (list 100
+        (stakers (list 50
             {
                 staker: principal,
                 start-reward-cycle: uint,
@@ -951,12 +954,16 @@
             }
         ))
     )
-    (ok (get registered
-        (fold count-registations stakers {
-            signer: (contract-of signer-manager),
-            registered: u0,
-        })
-    ))
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (ok (get registered
+            (fold count-registrations stakers {
+                signer: (contract-of signer-manager),
+                registered: u0,
+            })
+        ))
+    )
 )
 
 ;; Buy additional claim installments for an existing registration. Only the
@@ -991,6 +998,7 @@
                 signer-manager: signer-manager,
             })
         )
+        (try! (validate-no-reentrancy))
         (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
         ;; Fail before escrowing if this key is not registered or caller is not the sponsor.
         (let ((existing (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED)))
@@ -1317,7 +1325,6 @@
             (reward-cycle (/ claim-distribution u2))
             (bond-index (get bond-index registration))
         )
-        (asserts! (> (get remaining-claims registration) u0) ERR_NOT_REGISTERED)
         (asserts! (< claim-distribution current-distribution-cycle) ERR_ALREADY_CLAIMED)
         (asserts!
             (rewards-calculated-for-claim-distribution claim-distribution last-compute-distribution)

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -932,13 +932,13 @@
     )
 )
 
-;; Register up to 100 stakers under the same signer-manager in one call.
+;; Register up to 50 stakers under the same signer-manager in one call.
 ;; Runs register-for-claims-impl per entry. 
 ;;
 ;; Note that a failure for any entry does not abort the batch and print
 ;; events are emitted for both successful and failed registrations.
 ;;
-;; Ssee register-for-claims parameters documentation.
+;; See register-for-claims parameters documentation.
 ;;
 ;; Returns:
 ;;   ok with the number of stakers for which register-for-claims-impl

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -170,7 +170,7 @@
 ;; Returns:
 ;;   The registration tuple if present, otherwise none. The tuple holds
 ;;   bond-index, remaining-claims, one-claim-per-reward-cycle,
-;;   next-claim-distribution, prepaid-ustx, and payer.
+;;   next-claim-distribution, prepaid-ustx, and registrant.
 (define-read-only (get-registration
         (staker principal)
         (signer-manager principal)
@@ -780,7 +780,7 @@
 ;; --- Registration lifecycle helpers ---
 ;; register-for-claims / add-claims escrow STX and write the registration.
 ;; Advance burns one installment from escrow; cancel refunds the rest of
-;; the escrowed STX to the payer of the registration.
+;; the escrowed STX to the registrant of the registration.
 
 ;; Escrow the STX fee for the given number of claim installments unless
 ;; contract-caller is an admin. Returns the micro-STX amount escrowed.
@@ -797,6 +797,90 @@
             true
         )
         (ok amount)
+    )
+)
+
+;; Register a staker for automated reward claims. 
+;;
+;; See register-for-claims for documentation.
+(define-private (register-for-claims-impl
+        (staker principal)
+        (signer-manager principal)
+        (start-reward-cycle uint)
+        (one-claim-per-reward-cycle bool)
+        (fee uint)
+    )
+    (let (
+            (price (var-get fee-per-claim))
+            (num-claims (min-uint (/ fee price) MAX_CLAIM_INSTALLMENTS))
+            (key {
+                staker: staker,
+                signer-manager: signer-manager,
+            })
+            (position (unwrap! (get-position staker) ERR_NO_CURRENT_POSITION))
+        )
+        (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
+        (asserts! (is-none (map-get? registrations key)) ERR_ALREADY_REGISTERED)
+        (asserts! (is-eq signer-manager (get signer position)) ERR_SIGNER_MANAGER_MISMATCH)
+        (asserts! (>= start-reward-cycle (get first-reward-cycle position))
+            ERR_INVALID_START_REWARD_CYCLE
+        )
+        (let ((escrowed (try! (escrow-registration-fee num-claims))))
+            (map-set registrations key {
+                bond-index: (get bond-index position),
+                remaining-claims: num-claims,
+                one-claim-per-reward-cycle: one-claim-per-reward-cycle,
+                next-claim-distribution: (initial-next-claim-distribution start-reward-cycle one-claim-per-reward-cycle),
+                prepaid-ustx: escrowed,
+                registrant: contract-caller,
+            })
+            (ll-append key)
+            (print {
+                topic: "register-for-claims",
+                staker: staker,
+                registrant: contract-caller,
+                signer-manager: signer-manager,
+                start-reward-cycle: start-reward-cycle,
+                one-claim-per-reward-cycle: one-claim-per-reward-cycle,
+                num-claims: num-claims,
+                escrowed: escrowed,
+            })
+            (ok num-claims)
+        )
+    )
+)
+
+;; Fold step for register-many-for-claims: match each register-for-claims-impl
+;; result so a skip or failure doesn't abort the batch. Prints a skip event on
+;; failure. Returns the count in the accumulator's registered field.
+(define-private (count-registations
+        (entry {
+            staker: principal,
+            start-reward-cycle: uint,
+            one-claim-per-reward-cycle: bool,
+            fee: uint,
+        })
+        (state {
+            signer: principal,
+            registered: uint,
+        })
+    )
+    (match (register-for-claims-impl (get staker entry) (get signer state) (get start-reward-cycle entry)
+        (get one-claim-per-reward-cycle entry) (get fee entry)
+    )
+        num-claims (merge state { registered: (+ (get registered state) u1) })
+        err-code (begin
+            (print {
+                topic: "register-for-claims-skipped",
+                staker: (get staker entry),
+                signer-manager: (get signer state),
+                start-reward-cycle: (get start-reward-cycle entry),
+                one-claim-per-reward-cycle: (get one-claim-per-reward-cycle entry),
+                fee: (get fee entry),
+                error: err-code,
+            })
+            state
+        )
     )
 )
 
@@ -840,52 +924,45 @@
         (one-claim-per-reward-cycle bool)
         (fee uint)
     )
-    (let (
-            (price (var-get fee-per-claim))
-            (num-claims (min-uint (/ fee price) MAX_CLAIM_INSTALLMENTS))
-            (signer (contract-of signer-manager))
-            (key {
-                staker: staker,
-                signer-manager: signer,
-            })
-            (position (unwrap! (get-position staker) ERR_NO_CURRENT_POSITION))
-        )
-        ;; Validate before escrowing.
-        (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
-        (asserts! (is-none (map-get? registrations key)) ERR_ALREADY_REGISTERED)
-        (asserts! (is-eq signer (get signer position)) ERR_SIGNER_MANAGER_MISMATCH)
-        (asserts! (>= start-reward-cycle (get first-reward-cycle position))
-            ERR_INVALID_START_REWARD_CYCLE
-        )
-        (let ((escrowed (try! (escrow-registration-fee num-claims))))
-            (map-set registrations key {
-                bond-index: (get bond-index position),
-                remaining-claims: num-claims,
-                one-claim-per-reward-cycle: one-claim-per-reward-cycle,
-                next-claim-distribution: (initial-next-claim-distribution start-reward-cycle one-claim-per-reward-cycle),
-                prepaid-ustx: escrowed,
-                registrant: contract-caller,
-            })
-            (ll-append key)
-            (print {
-                topic: "register-for-claims",
-                staker: staker,
-                registrant: contract-caller,
-                signer-manager: signer,
-                start-reward-cycle: start-reward-cycle,
-                one-claim-per-reward-cycle: one-claim-per-reward-cycle,
-                num-claims: num-claims,
-                escrowed: escrowed,
-            })
-            (ok num-claims)
-        )
+    (register-for-claims-impl staker (contract-of signer-manager) start-reward-cycle
+        one-claim-per-reward-cycle fee
     )
+)
+
+;; Register up to 100 stakers under the same signer-manager in one call.
+;; Runs register-for-claims-impl per entry. 
+;;
+;; Note that a failure for any entry does not abort the batch and print
+;; events are emitted for both successful and failed registrations.
+;;
+;; Ssee register-for-claims parameters documentation.
+;;
+;; Returns:
+;;   ok with the number of stakers for which register-for-claims-impl
+;;   returned ok.
+(define-public (register-many-for-claims
+        (signer-manager <reward-claim-signer-manager-trait>)
+        (stakers (list 100
+            {
+                staker: principal,
+                start-reward-cycle: uint,
+                one-claim-per-reward-cycle: bool,
+                fee: uint,
+            }
+        ))
+    )
+    (ok (get registered
+        (fold count-registations stakers {
+            signer: (contract-of signer-manager),
+            registered: u0,
+        })
+    ))
 )
 
 ;; Buy additional claim installments for an existing registration. Only the
 ;; stored registrant may call this. Does not change next-claim-distribution,
-;; one-claim-per-reward-cycle, bond-index, or payer. Fee STX is escrowed and
-;; burned later on advance.
+;; one-claim-per-reward-cycle, bond-index, or registrant. Fee STX is escrowed
+;; and burned later when a claim is processed.
 ;;
 ;; Parameters:
 ;;   staker          The staker on the registration key.
@@ -978,7 +1055,9 @@
             (ll-remove key)
             (begin
                 (if (> refund u0)
-                    (try! (as-contract? ((with-stx refund)) (try! (stx-transfer? refund tx-sender registrant))))
+                    (try! (as-contract? ((with-stx refund))
+                        (try! (stx-transfer? refund tx-sender registrant))
+                    ))
                     true
                 )
                 (print {

--- a/contracts/contracts/reward-claim-registry.clar
+++ b/contracts/contracts/reward-claim-registry.clar
@@ -75,7 +75,7 @@
 (define-constant ERR_UNKNOWN_PENDING_WITHDRAWAL (err u607))
 ;; start-reward-cycle is before the position's first-reward-cycle
 (define-constant ERR_INVALID_START_REWARD_CYCLE (err u608))
-;; This is returned when the contract-caller is not the sponsor for add-claims
+;; This is returned when the tx-sender is not the sponsor for add-claims
 ;; calls, or not the staker or sponsor for cancel-registration calls.
 (define-constant ERR_UNAUTHORIZED (err u609))
 ;; A registration already exists for this staker and signer-manager
@@ -155,8 +155,8 @@
         ;; is cancelled.
         prepaid-ustx: uint,
         ;; The principal that created this registration and whose STX is
-        ;; escrowed in prepaid-ustx. The only caller allowed to add-claims.
-        ;; Cancel refunds remaining prepaid-ustx to this principal.
+        ;; escrowed in prepaid-ustx. It is the only principal allowed to add
+        ;; claims. Cancellation refunds remaining prepaid-ustx to this principal.
         sponsor: principal,
     }
 )
@@ -782,17 +782,17 @@
 ;; the escrowed STX to the sponsor of the registration.
 
 ;; Escrow the STX fee for the given number of claim installments unless
-;; contract-caller is an admin. Returns the micro-STX amount escrowed.
+;; tx-sender is an admin. Returns the micro-STX amount escrowed.
 (define-private (escrow-registration-fee (num-claims uint))
     (let (
             (price (var-get fee-per-claim))
-            (amount (if (is-admin contract-caller)
+            (amount (if (is-admin tx-sender)
                 u0
                 (* num-claims price)
             ))
         )
         (if (> amount u0)
-            (try! (stx-transfer? amount contract-caller current-contract))
+            (try! (stx-transfer? amount tx-sender current-contract))
             true
         )
         (ok amount)
@@ -831,13 +831,13 @@
                 one-claim-per-reward-cycle: one-claim-per-reward-cycle,
                 next-claim-distribution: (initial-next-claim-distribution start-reward-cycle one-claim-per-reward-cycle),
                 prepaid-ustx: escrowed,
-                sponsor: contract-caller,
+                sponsor: tx-sender,
             })
             (ll-append key)
             (print {
                 topic: "register-for-claims",
                 staker: staker,
-                sponsor: contract-caller,
+                sponsor: tx-sender,
                 signer-manager: signer-manager,
                 start-reward-cycle: start-reward-cycle,
                 one-claim-per-reward-cycle: one-claim-per-reward-cycle,
@@ -884,11 +884,11 @@
 )
 
 ;; Register a staker for automated reward claims. Anyone may call this;
-;; contract-caller is stored as `sponsor` and is the only principal that may
+;; tx-sender is stored as `sponsor` and is the only principal that may
 ;; add-claims. Admins pay no fee. The staker must currently be staking in
 ;; pox-5. The active bond-index, if any, is looked up from pox-5; callers do
 ;; not pass it. Schedule seeds next-claim-distribution from start-reward-cycle.
-;; Fee STX is escrowed in this contract and burned one installment at a time
+;; Fee STX is escrowed from tx-sender and burned one installment at a time
 ;; when claims advance. Fails if this staker and signer-manager pair is already
 ;; registered; use add-claims to buy more installments.
 ;;
@@ -905,11 +905,11 @@
 ;;                               false, up to two claims per reward cycle: step
 ;;                               of one, seeded on the first half, with catch-up
 ;;                               when a reward cycle is fully past.
-;;   fee                         STX paid by contract-caller. Buys the minimum of
+;;   fee                         STX paid by tx-sender. Buys the minimum of
 ;;                               fee divided by fee-per-claim and
 ;;                               MAX_CLAIM_INSTALLMENTS.
 ;;                               Only the used portion is escrowed; any remainder
-;;                               stays with the caller. Admins escrow nothing.
+;;                               stays with the sender. Admins escrow nothing.
 ;;
 ;; Returns:
 ;;   ok with the number of claim installments bought on this call, or an error
@@ -974,14 +974,14 @@
 ;; Parameters:
 ;;   staker          The staker on the registration key.
 ;;   signer-manager  The signer-manager principal on the registration key.
-;;   fee             STX paid by contract-caller. Buys the minimum of fee divided by
+;;   fee             STX paid by tx-sender. Buys the minimum of fee divided by
 ;;                   fee-per-claim and MAX_CLAIM_INSTALLMENTS. Only the used portion
-;;                   is escrowed; any remainder stays with the caller. Admins
+;;                   is escrowed; any remainder stays with the sender. Admins
 ;;                   escrow nothing.
 ;;
 ;; Returns:
 ;;   ok with the number of claim installments added on this call, or an error
-;;   if the caller is not the sponsor, fee buys no claims, or no registration
+;;   if tx-sender is not the sponsor, fee buys no claims, or no registration
 ;;   exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
@@ -1000,9 +1000,9 @@
         )
         (try! (validate-no-reentrancy))
         (asserts! (> num-claims u0) ERR_INSUFFICIENT_FEE)
-        ;; Fail before escrowing if this key is not registered or caller is not the sponsor.
+        ;; Fail before escrowing if this key is not registered or tx-sender is not the sponsor.
         (let ((existing (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED)))
-            (asserts! (is-eq contract-caller (get sponsor existing)) ERR_UNAUTHORIZED)
+            (asserts! (is-eq tx-sender (get sponsor existing)) ERR_UNAUTHORIZED)
             (let ((escrowed (try! (escrow-registration-fee num-claims))))
                 (map-set registrations key
                     (merge existing {
@@ -1013,13 +1013,81 @@
                 (print {
                     topic: "add-claims",
                     staker: staker,
-                    sponsor: contract-caller,
+                    sponsor: tx-sender,
                     signer-manager: signer-manager,
                     num-claims: num-claims,
                     escrowed: escrowed,
                 })
                 (ok num-claims)
             )
+        )
+    )
+)
+
+;; Core cancel path shared by cancel-registration and cancel-many-registrations.
+;; Deletes the registration, refunds remaining prepaid-ustx to the sponsor, and
+;; returns the refund amount.
+;;
+;; #[allow(unchecked_data)]
+(define-private (cancel-registration-impl
+        (staker principal)
+        (signer-manager principal)
+    )
+    (let (
+            (key {
+                staker: staker,
+                signer-manager: signer-manager,
+            })
+            (registration (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
+            (refund (get prepaid-ustx registration))
+            (sponsor (get sponsor registration))
+        )
+        (asserts! (or (is-eq tx-sender staker) (is-eq tx-sender sponsor))
+            ERR_UNAUTHORIZED
+        )
+        (map-delete registrations key)
+        (ll-remove key)
+        (begin
+            (if (> refund u0)
+                (try! (as-contract? ((with-stx refund))
+                    (try! (stx-transfer? refund tx-sender sponsor))
+                ))
+                true
+            )
+            (print {
+                topic: "cancel-registration",
+                staker: staker,
+                sponsor: sponsor,
+                signer-manager: signer-manager,
+                refund: refund,
+            })
+            (ok refund)
+        )
+    )
+)
+
+;; Fold step for cancel-many-registrations: match each cancel-registration-impl
+;; result so a skip or failure doesn't abort the batch. Prints a skip event on
+;; failure. Returns the count in the accumulator's cancelled field.
+;;
+;; #[allow(unchecked_data)]
+(define-private (count-cancellations
+        (staker principal)
+        (state {
+            signer-manager: principal,
+            cancelled: uint,
+        })
+    )
+    (match (cancel-registration-impl staker (get signer-manager state))
+        refund (merge state { cancelled: (+ (get cancelled state) u1) })
+        err-code (begin
+            (print {
+                topic: "cancel-registration-skipped",
+                staker: staker,
+                signer-manager: (get signer-manager state),
+                error: err-code,
+            })
+            state
         )
     )
 )
@@ -1036,7 +1104,7 @@
 ;;
 ;; Returns:
 ;;   ok with the micro-STX refunded to the sponsor, ERR_UNAUTHORIZED
-;;   if contract-caller is neither the staker nor the sponsor, or
+;;   if tx-sender is neither the staker nor the sponsor, or
 ;;   ERR_NOT_REGISTERED if no registration exists for this key.
 ;;
 ;; #[allow(unchecked_data)]
@@ -1047,37 +1115,37 @@
     (begin
         ;; ensure no reentrancy through signer-manager trait calls
         (try! (validate-no-reentrancy))
-        (let (
-                (key {
-                    staker: staker,
-                    signer-manager: signer-manager,
-                })
-                (registration (unwrap! (map-get? registrations key) ERR_NOT_REGISTERED))
-                (refund (get prepaid-ustx registration))
-                (sponsor (get sponsor registration))
-            )
-            (asserts! (or (is-eq contract-caller staker) (is-eq contract-caller sponsor))
-                ERR_UNAUTHORIZED
-            )
-            (map-delete registrations key)
-            (ll-remove key)
-            (begin
-                (if (> refund u0)
-                    (try! (as-contract? ((with-stx refund))
-                        (try! (stx-transfer? refund tx-sender sponsor))
-                    ))
-                    true
-                )
-                (print {
-                    topic: "cancel-registration",
-                    staker: staker,
-                    sponsor: sponsor,
-                    signer-manager: signer-manager,
-                    refund: refund,
-                })
-                (ok refund)
-            )
-        )
+        (cancel-registration-impl staker signer-manager)
+    )
+)
+
+;; Cancel up to 50 registrations under the same signer-manager in one call.
+;; Runs cancel-registration-impl per staker. Skips without aborting the batch
+;; any entry that is not registered or that the caller is not authorized to
+;; cancel; failures emit a cancel-registration-skipped print event.
+;;
+;; Parameters:
+;;   signer-manager  The signer-manager principal shared by every staker.
+;;   stakers         Up to 50 staker principals to cancel in order.
+;;
+;; Returns:
+;;   ok with the number of stakers for which cancel-registration-impl returned
+;;   ok (zero when the list is empty or every entry is skipped).
+;;
+;; #[allow(unchecked_data)]
+(define-public (cancel-many-registrations
+        (signer-manager principal)
+        (stakers (list 50 principal))
+    )
+    (begin
+        ;; ensure no reentrancy through signer-manager trait calls
+        (try! (validate-no-reentrancy))
+        (ok (get cancelled
+            (fold count-cancellations stakers {
+                signer-manager: signer-manager,
+                cancelled: u0,
+            })
+        ))
     )
 )
 

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -684,6 +684,35 @@ export function addClaims(
   );
 }
 
+export function cancelRegistration(
+  staker: string,
+  sender: string,
+  signerManager: string,
+) {
+  return simnet.callPublicFn(
+    "reward-claim-registry",
+    "cancel-registration",
+    [Cl.principal(staker), Cl.principal(signerManager)],
+    sender,
+  );
+}
+
+export function cancelManyRegistrations(
+  stakers: string[],
+  sender: string,
+  signerManager: string,
+) {
+  return simnet.callPublicFn(
+    "reward-claim-registry",
+    "cancel-many-registrations",
+    [
+      Cl.principal(signerManager),
+      Cl.list(stakers.map((staker) => Cl.principal(staker))),
+    ],
+    sender,
+  );
+}
+
 export function processRewardClaim(
   staker: string,
   sender: string,

--- a/contracts/tests/pox-5-fixtures.ts
+++ b/contracts/tests/pox-5-fixtures.ts
@@ -638,6 +638,38 @@ export function registerForClaims(
   );
 }
 
+export type RegisterManyEntry = {
+  staker: string;
+  startRewardCycle: bigint;
+  oneClaimPerRewardCycle: boolean;
+  fee: bigint;
+};
+
+export function registerManyForClaims(
+  stakers: RegisterManyEntry[],
+  sender: string,
+  signerManager: string,
+) {
+  return simnet.callPublicFn(
+    "reward-claim-registry",
+    "register-many-for-claims",
+    [
+      Cl.principal(signerManager),
+      Cl.list(
+        stakers.map((entry) =>
+          Cl.tuple({
+            staker: Cl.principal(entry.staker),
+            "start-reward-cycle": Cl.uint(entry.startRewardCycle),
+            "one-claim-per-reward-cycle": Cl.bool(entry.oneClaimPerRewardCycle),
+            fee: Cl.uint(entry.fee),
+          }),
+        ),
+      ),
+    ],
+    sender,
+  );
+}
+
 export function addClaims(
   staker: string,
   fee: bigint,

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -98,7 +98,7 @@ function stxRegistration(
   remaining: bigint,
   nextClaimDistribution: bigint,
   prepaid: bigint = remaining * FEE_PER_CLAIM,
-  registrant: string = wallet1,
+  sponsor: string = wallet1,
 ) {
   return Cl.tuple({
     "bond-index": Cl.none(),
@@ -106,7 +106,7 @@ function stxRegistration(
     "one-claim-per-reward-cycle": Cl.bool(true),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
-    registrant: Cl.principal(registrant),
+    sponsor: Cl.principal(sponsor),
   });
 }
 
@@ -115,7 +115,7 @@ function bondRegistration(
   remaining: bigint,
   nextClaimDistribution: bigint,
   prepaid: bigint = remaining * FEE_PER_CLAIM,
-  registrant: string = wallet1,
+  sponsor: string = wallet1,
 ) {
   return Cl.tuple({
     "bond-index": Cl.some(Cl.uint(bondIndex)),
@@ -123,7 +123,7 @@ function bondRegistration(
     "one-claim-per-reward-cycle": Cl.bool(false),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
-    registrant: Cl.principal(registrant),
+    sponsor: Cl.principal(sponsor),
   });
 }
 
@@ -177,7 +177,7 @@ function registrationRow(
   prepaid: bigint = remaining * FEE_PER_CLAIM,
   oneClaimPerRewardCycle = true,
   bondIndex: OptionalCV<UIntCV> = Cl.none(),
-  registrant: string = staker,
+  sponsor: string = staker,
 ) {
   return Cl.tuple({
     staker: Cl.principal(staker),
@@ -187,7 +187,7 @@ function registrationRow(
     "one-claim-per-reward-cycle": Cl.bool(oneClaimPerRewardCycle),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
-    registrant: Cl.principal(registrant),
+    sponsor: Cl.principal(sponsor),
   });
 }
 
@@ -410,7 +410,7 @@ describe("register-for-claims", () => {
     );
   });
 
-  it("lets a third party register a staker and records them as registrant", () => {
+  it("lets a third party register a staker and records them as sponsor", () => {
     const before = stxBalance(wallet2);
     expect(
       registerForClaims(wallet1, FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true).result,
@@ -485,7 +485,7 @@ describe("register-many-for-claims", () => {
         "one-claim-per-reward-cycle": Cl.bool(false),
         "next-claim-distribution": Cl.uint(initialNextClaimDistribution(start2, false)),
         "prepaid-ustx": Cl.uint(5n * FEE_PER_CLAIM),
-        registrant: Cl.principal(wallet3),
+        sponsor: Cl.principal(wallet3),
       }),
     );
   });
@@ -558,8 +558,8 @@ describe("register-many-for-claims", () => {
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
   });
 
-  it("registers 100 stakers in one call", () => {
-    const TOTAL = 100;
+  it("registers 50 stakers in one call", () => {
+    const TOTAL = 50;
     const stakers = Array.from({ length: TOTAL }, (_, i) => {
       const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
       return privateKeyToAddress(hex, "testnet");
@@ -2211,23 +2211,23 @@ describe("reentrancy", () => {
     expectSingleAdvance();
   });
 
-  it("rejects add-claims reentry when the signer-manager is not the payer", () => {
+  it("blocks add-claims reentry with ERR_REENTRANT_CALL", () => {
     advanceToPending();
     setMaliciousReenterMode(REENTER_ADD_CLAIMS, wallet1);
     expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
       Cl.none(),
     );
-    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_UNAUTHORIZED));
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
     expectSingleAdvance();
   });
 
-  it("rejects register-for-claims reentry with a mismatched signer-manager", () => {
+  it("blocks register-for-claims reentry with ERR_REENTRANT_CALL", () => {
     advanceToPending();
     setMaliciousReenterMode(REENTER_REGISTER, wallet1);
     expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
       Cl.none(),
     );
-    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_SIGNER_MANAGER_MISMATCH));
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_REENTRANT_CALL));
     expectSingleAdvance();
   });
 });

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -22,6 +22,7 @@ import {
   REENTER_REGISTER,
   REENTER_SETTLE,
   addClaims,
+  cancelManyRegistrations,
   MOCK_SIGNER_MANAGER,
   SIGNER_MANAGER,
   SIGNER_PRIVATE_KEY,
@@ -817,6 +818,97 @@ describe("cancel-registration", () => {
       ).result,
     ).toBeOk(Cl.bool(true));
     expect(getPendingWithdrawals()).toBeOk(pendingWithdrawalsPage([]));
+  });
+});
+
+describe("cancel-many-registrations", () => {
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    stakeFor(wallet1, SIGNER_SET_MIN_USTX, 2n);
+    stakeFor(wallet2, SIGNER_SET_MIN_USTX, 2n);
+  });
+
+  it("cancels multiple registrations and returns the count", () => {
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet3, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, 2n * FEE_PER_CLAIM, wallet3, SIGNER_MANAGER, STX_START, true);
+
+    const before = stxBalance(wallet3);
+    const { result } = cancelManyRegistrations([wallet1, wallet2], wallet3, SIGNER_MANAGER);
+    expect(result).toBeOk(Cl.uint(2));
+    expect(stxBalance(wallet3) - before).toBe(5n * FEE_PER_CLAIM);
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
+  });
+
+  it("lets the staker cancel their own rows in a batch", () => {
+    registerForClaims(wallet1, FEE_PER_CLAIM, wallet3, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, FEE_PER_CLAIM, wallet3, SIGNER_MANAGER, STX_START, true);
+
+    const beforeSponsor = stxBalance(wallet3);
+    expect(
+      cancelManyRegistrations([wallet1], wallet1, SIGNER_MANAGER).result,
+    ).toBeOk(Cl.uint(1));
+    expect(stxBalance(wallet3) - beforeSponsor).toBe(FEE_PER_CLAIM);
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet3),
+    );
+  });
+
+  it("returns zero when the staker list is empty", () => {
+    expect(
+      cancelManyRegistrations([], wallet3, SIGNER_MANAGER).result,
+    ).toBeOk(Cl.uint(0));
+  });
+
+  it("skips unregistered and unauthorized stakers without aborting the batch", () => {
+    registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    registerForClaims(wallet2, FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+
+    // wallet3 is not staker or sponsor for either row; wallet1 can cancel own row only.
+    expect(
+      cancelManyRegistrations([wallet1, wallet2, wallet3], wallet1, SIGNER_MANAGER).result,
+    ).toBeOk(Cl.uint(1));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet2),
+    );
+  });
+
+  it("cancels 50 stakers in one call", () => {
+    const TOTAL = 50;
+    const stakers = Array.from({ length: TOTAL }, (_, i) => {
+      const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+      return privateKeyToAddress(hex, "testnet");
+    });
+
+    for (const staker of stakers) {
+      expect(
+        simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+      ).toBeOk(Cl.bool(true));
+      stakeFor(staker, SIGNER_SET_MIN_USTX, 2n);
+    }
+
+    expect(
+      registerManyForClaims(
+        stakers.map((staker) => ({
+          staker,
+          fee: FEE_PER_CLAIM,
+          startRewardCycle: STX_START,
+          oneClaimPerRewardCycle: true,
+        })),
+        wallet3,
+        SIGNER_MANAGER,
+      ).result,
+    ).toBeOk(Cl.uint(TOTAL));
+
+    const before = stxBalance(wallet3);
+    const { result } = cancelManyRegistrations(stakers, wallet3, SIGNER_MANAGER);
+    expect(result).toBeOk(Cl.uint(TOTAL));
+    expect(stxBalance(wallet3) - before).toBe(BigInt(TOTAL) * FEE_PER_CLAIM);
+    expect(getRegistration(stakers[0]!, SIGNER_MANAGER)).toBeNone();
+    expect(getRegistration(stakers[TOTAL - 1]!, SIGNER_MANAGER)).toBeNone();
   });
 });
 

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -97,6 +97,7 @@ function stxRegistration(
   remaining: bigint,
   nextClaimDistribution: bigint,
   prepaid: bigint = remaining * FEE_PER_CLAIM,
+  payer: string = wallet1,
 ) {
   return Cl.tuple({
     "bond-index": Cl.none(),
@@ -104,6 +105,7 @@ function stxRegistration(
     "one-claim-per-reward-cycle": Cl.bool(true),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
+    payer: Cl.principal(payer),
   });
 }
 
@@ -112,6 +114,7 @@ function bondRegistration(
   remaining: bigint,
   nextClaimDistribution: bigint,
   prepaid: bigint = remaining * FEE_PER_CLAIM,
+  payer: string = wallet1,
 ) {
   return Cl.tuple({
     "bond-index": Cl.some(Cl.uint(bondIndex)),
@@ -119,6 +122,7 @@ function bondRegistration(
     "one-claim-per-reward-cycle": Cl.bool(false),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
+    payer: Cl.principal(payer),
   });
 }
 
@@ -172,6 +176,7 @@ function registrationRow(
   prepaid: bigint = remaining * FEE_PER_CLAIM,
   oneClaimPerRewardCycle = true,
   bondIndex: OptionalCV<UIntCV> = Cl.none(),
+  payer: string = staker,
 ) {
   return Cl.tuple({
     staker: Cl.principal(staker),
@@ -181,6 +186,7 @@ function registrationRow(
     "one-claim-per-reward-cycle": Cl.bool(oneClaimPerRewardCycle),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
+    payer: Cl.principal(payer),
   });
 }
 
@@ -334,7 +340,7 @@ describe("register-for-claims", () => {
     expect(result).toBeOk(Cl.uint(3));
     expect(stxBalance(deployer)).toBe(before);
     expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
-      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 0n),
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 0n, deployer),
     );
   });
 
@@ -403,11 +409,15 @@ describe("register-for-claims", () => {
     );
   });
 
-  it("rejects a third party who is not an admin", () => {
+  it("lets a third party register a staker and records them as payer", () => {
+    const before = stxBalance(wallet2);
     expect(
       registerForClaims(wallet1, FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true).result,
-    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
-    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
+    ).toBeOk(Cl.uint(1));
+    expect(before - stxBalance(wallet2)).toBe(FEE_PER_CLAIM);
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet2),
+    );
   });
 
   it("is not pending until next-claim-distribution has elapsed", () => {
@@ -458,7 +468,7 @@ describe("add-claims", () => {
     );
   });
 
-  it("rejects a third party who is not an admin", () => {
+  it("rejects a caller who is not the payer", () => {
     registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
     expect(addClaims(wallet1, 2n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER).result).toBeErr(
       Cl.uint(ERR_UNAUTHORIZED),
@@ -468,13 +478,31 @@ describe("add-claims", () => {
     );
   });
 
-  it("lets an admin add claims for a staker", () => {
+  it("rejects an admin adding claims when they are not the payer", () => {
     registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
+    expect(addClaims(wallet1, 2n * FEE_PER_CLAIM, deployer, SIGNER_MANAGER).result).toBeErr(
+      Cl.uint(ERR_UNAUTHORIZED),
+    );
+  });
+
+  it("lets a third-party payer add claims and rejects the staker topping up that row", () => {
+    registerForClaims(wallet1, FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    expect(addClaims(wallet1, 2n * FEE_PER_CLAIM, wallet1, SIGNER_MANAGER).result).toBeErr(
+      Cl.uint(ERR_UNAUTHORIZED),
+    );
+    expect(addClaims(wallet1, 2n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER).result).toBeOk(Cl.uint(2));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 3n * FEE_PER_CLAIM, wallet2),
+    );
+  });
+
+  it("lets the payer add claims, including an admin who sponsored the registration", () => {
+    registerForClaims(wallet1, FEE_PER_CLAIM, deployer, SIGNER_MANAGER, STX_START, true);
     const before = stxBalance(deployer);
     expect(addClaims(wallet1, 2n * FEE_PER_CLAIM, deployer, SIGNER_MANAGER).result).toBeOk(Cl.uint(2));
     expect(stxBalance(deployer)).toBe(before);
     expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
-      stxRegistration(3n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM),
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 0n, deployer),
     );
   });
 });
@@ -525,7 +553,39 @@ describe("cancel-registration", () => {
     expect(stxBalance(wallet1) - before).toBe(2n * FEE_PER_CLAIM);
   });
 
-  it("rejects a caller who is not the staker", () => {
+  it("lets the payer cancel and refunds remaining escrow to the payer", () => {
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    const beforePayer = stxBalance(wallet2);
+    const beforeStaker = stxBalance(wallet1);
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "cancel-registration",
+        [Cl.principal(wallet1), Cl.principal(SIGNER_MANAGER)],
+        wallet2,
+      ).result,
+    ).toBeOk(Cl.uint(3n * FEE_PER_CLAIM));
+    expect(stxBalance(wallet2) - beforePayer).toBe(3n * FEE_PER_CLAIM);
+    expect(stxBalance(wallet1)).toBe(beforeStaker);
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
+  });
+
+  it("lets the staker cancel a third-party registration and still refunds the payer", () => {
+    registerForClaims(wallet1, 3n * FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true);
+    const beforePayer = stxBalance(wallet2);
+    expect(
+      simnet.callPublicFn(
+        "reward-claim-registry",
+        "cancel-registration",
+        [Cl.principal(wallet1), Cl.principal(SIGNER_MANAGER)],
+        wallet1,
+      ).result,
+    ).toBeOk(Cl.uint(3n * FEE_PER_CLAIM));
+    expect(stxBalance(wallet2) - beforePayer).toBe(3n * FEE_PER_CLAIM);
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
+  });
+
+  it("rejects a caller who is neither the staker nor the payer", () => {
     registerForClaims(wallet1, FEE_PER_CLAIM, wallet1, SIGNER_MANAGER, STX_START, true);
     expect(
       simnet.callPublicFn(
@@ -540,7 +600,7 @@ describe("cancel-registration", () => {
     );
   });
 
-  it("rejects an admin canceling on behalf of a staker they registered", () => {
+  it("lets a payer who sponsored the registration cancel it", () => {
     registerForClaims(wallet1, 3n * FEE_PER_CLAIM, deployer, SIGNER_MANAGER, STX_START, true);
     expect(
       simnet.callPublicFn(
@@ -549,10 +609,8 @@ describe("cancel-registration", () => {
         [Cl.principal(wallet1), Cl.principal(SIGNER_MANAGER)],
         deployer,
       ).result,
-    ).toBeErr(Cl.uint(ERR_UNAUTHORIZED));
-    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
-      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 0n),
-    );
+    ).toBeOk(Cl.uint(0));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeNone();
   });
 
   it("rejects when no registration exists", () => {
@@ -764,7 +822,7 @@ describe("get-pending-claims", () => {
       stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
     );
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
-      stxRegistration(3n, STX_FIRST_CLAIM_DIST),
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 3n * FEE_PER_CLAIM, wallet2),
     );
   });
 
@@ -1169,7 +1227,7 @@ describe("process-reward-claims (batch)", () => {
       stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
     );
     expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
-      stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
+      stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n, 2n * FEE_PER_CLAIM, wallet2),
     );
     expect(getPendingClaims()).toBeOk(pendingClaimsPage([]));
   });
@@ -1992,7 +2050,7 @@ describe("reentrancy", () => {
     expectSingleAdvance();
   });
 
-  it("rejects add-claims reentry via authorize-staker-or-admin, not the reentrancy gate", () => {
+  it("rejects add-claims reentry when the signer-manager is not the payer", () => {
     advanceToPending();
     setMaliciousReenterMode(REENTER_ADD_CLAIMS, wallet1);
     expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
@@ -2002,13 +2060,13 @@ describe("reentrancy", () => {
     expectSingleAdvance();
   });
 
-  it("rejects register-for-claims reentry via authorize-staker-or-admin, not the reentrancy gate", () => {
+  it("rejects register-for-claims reentry with a mismatched signer-manager", () => {
     advanceToPending();
     setMaliciousReenterMode(REENTER_REGISTER, wallet1);
     expect(processRewardClaim(wallet1, wallet1, MALICIOUS_SIGNER_MANAGER).result).toBeOk(
       Cl.none(),
     );
-    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_UNAUTHORIZED));
+    expect(getMaliciousLastReenterError()).toBeSome(Cl.uint(ERR_SIGNER_MANAGER_MISMATCH));
     expectSingleAdvance();
   });
 });
@@ -2086,7 +2144,7 @@ describe("withdrawal-request ids that are not a live sBTC pending request", () =
       ]),
     );
     expect(getRegistration(wallet3, MOCK_SIGNER_MANAGER)).toBeSome(
-      stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n),
+      stxRegistration(2n, STX_FIRST_CLAIM_DIST + 2n, 2n * FEE_PER_CLAIM, wallet3),
     );
   });
 

--- a/contracts/tests/reward-claim-registry.test.ts
+++ b/contracts/tests/reward-claim-registry.test.ts
@@ -52,6 +52,7 @@ import {
   processRewardClaim,
   registerForBond,
   registerForClaims,
+  registerManyForClaims,
   registerMockSignerManager,
   registerSignerManager,
   rejectWithdrawal,
@@ -97,7 +98,7 @@ function stxRegistration(
   remaining: bigint,
   nextClaimDistribution: bigint,
   prepaid: bigint = remaining * FEE_PER_CLAIM,
-  payer: string = wallet1,
+  registrant: string = wallet1,
 ) {
   return Cl.tuple({
     "bond-index": Cl.none(),
@@ -105,7 +106,7 @@ function stxRegistration(
     "one-claim-per-reward-cycle": Cl.bool(true),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
-    payer: Cl.principal(payer),
+    registrant: Cl.principal(registrant),
   });
 }
 
@@ -114,7 +115,7 @@ function bondRegistration(
   remaining: bigint,
   nextClaimDistribution: bigint,
   prepaid: bigint = remaining * FEE_PER_CLAIM,
-  payer: string = wallet1,
+  registrant: string = wallet1,
 ) {
   return Cl.tuple({
     "bond-index": Cl.some(Cl.uint(bondIndex)),
@@ -122,7 +123,7 @@ function bondRegistration(
     "one-claim-per-reward-cycle": Cl.bool(false),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
-    payer: Cl.principal(payer),
+    registrant: Cl.principal(registrant),
   });
 }
 
@@ -176,7 +177,7 @@ function registrationRow(
   prepaid: bigint = remaining * FEE_PER_CLAIM,
   oneClaimPerRewardCycle = true,
   bondIndex: OptionalCV<UIntCV> = Cl.none(),
-  payer: string = staker,
+  registrant: string = staker,
 ) {
   return Cl.tuple({
     staker: Cl.principal(staker),
@@ -186,7 +187,7 @@ function registrationRow(
     "one-claim-per-reward-cycle": Cl.bool(oneClaimPerRewardCycle),
     "next-claim-distribution": Cl.uint(nextClaimDistribution),
     "prepaid-ustx": Cl.uint(prepaid),
-    payer: Cl.principal(payer),
+    registrant: Cl.principal(registrant),
   });
 }
 
@@ -409,7 +410,7 @@ describe("register-for-claims", () => {
     );
   });
 
-  it("lets a third party register a staker and records them as payer", () => {
+  it("lets a third party register a staker and records them as registrant", () => {
     const before = stxBalance(wallet2);
     expect(
       registerForClaims(wallet1, FEE_PER_CLAIM, wallet2, SIGNER_MANAGER, STX_START, true).result,
@@ -425,6 +426,166 @@ describe("register-for-claims", () => {
     expect(getPendingClaims()).toBeOk(pendingClaimsPage([]));
     mineUntilPastDistribution(STX_FIRST_CLAIM_DIST);
     expect(getPendingClaims()).toBeOk(pendingClaimsPage([pendingRow(wallet1, STX_START, Cl.none())]));
+  });
+});
+
+describe("register-many-for-claims", () => {
+  const entry = (
+    staker: string,
+    fee: bigint = FEE_PER_CLAIM,
+    startRewardCycle: bigint = STX_START,
+    oneClaimPerRewardCycle = true,
+  ) => ({
+    staker,
+    fee,
+    startRewardCycle,
+    oneClaimPerRewardCycle,
+  });
+
+  beforeEach(() => {
+    initPox5();
+    registerSignerManager(SIGNER_PRIVATE_KEY);
+    stakeFor(wallet1, SIGNER_SET_MIN_USTX, 2n);
+    stakeFor(wallet2, SIGNER_SET_MIN_USTX, 2n);
+  });
+
+  it("registers multiple stakers and returns the count", () => {
+    const { result } = registerManyForClaims(
+      [entry(wallet1, 3n * FEE_PER_CLAIM), entry(wallet2, 3n * FEE_PER_CLAIM)],
+      wallet3,
+      SIGNER_MANAGER,
+    );
+    expect(result).toBeOk(Cl.uint(2));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 3n * FEE_PER_CLAIM, wallet3),
+    );
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 3n * FEE_PER_CLAIM, wallet3),
+    );
+  });
+
+  it("applies per-entry fee, start cycle, and cadence", () => {
+    const start2 = 2n;
+    const { result } = registerManyForClaims(
+      [
+        entry(wallet1, 2n * FEE_PER_CLAIM, STX_START, true),
+        entry(wallet2, 5n * FEE_PER_CLAIM, start2, false),
+      ],
+      wallet3,
+      SIGNER_MANAGER,
+    );
+    expect(result).toBeOk(Cl.uint(2));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(2n, STX_FIRST_CLAIM_DIST, 2n * FEE_PER_CLAIM, wallet3),
+    );
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
+      Cl.tuple({
+        "bond-index": Cl.none(),
+        "remaining-claims": Cl.uint(5),
+        "one-claim-per-reward-cycle": Cl.bool(false),
+        "next-claim-distribution": Cl.uint(initialNextClaimDistribution(start2, false)),
+        "prepaid-ustx": Cl.uint(5n * FEE_PER_CLAIM),
+        registrant: Cl.principal(wallet3),
+      }),
+    );
+  });
+
+  it("escrows the total used fee across all stakers", () => {
+    const before = stxBalance(wallet3);
+    registerManyForClaims(
+      [entry(wallet1, 3n * FEE_PER_CLAIM), entry(wallet2, FEE_PER_CLAIM)],
+      wallet3,
+      SIGNER_MANAGER,
+    );
+    expect(before - stxBalance(wallet3)).toBe(4n * FEE_PER_CLAIM);
+  });
+
+  it("escrows nothing when an admin registers a batch", () => {
+    const before = stxBalance(deployer);
+    const { result } = registerManyForClaims(
+      [entry(wallet1, 3n * FEE_PER_CLAIM), entry(wallet2, 3n * FEE_PER_CLAIM)],
+      deployer,
+      SIGNER_MANAGER,
+    );
+    expect(result).toBeOk(Cl.uint(2));
+    expect(stxBalance(deployer)).toBe(before);
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 0n, deployer),
+    );
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(3n, STX_FIRST_CLAIM_DIST, 0n, deployer),
+    );
+  });
+
+  it("returns zero when the staker list is empty", () => {
+    expect(
+      registerManyForClaims([], wallet3, SIGNER_MANAGER).result,
+    ).toBeOk(Cl.uint(0));
+  });
+
+  it("skips duplicate stakers without aborting the batch", () => {
+    expect(
+      registerManyForClaims([entry(wallet1), entry(wallet1)], wallet3, SIGNER_MANAGER).result,
+    ).toBeOk(Cl.uint(1));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet3),
+    );
+  });
+
+  it("skips invalid stakers without aborting the batch", () => {
+    const before = stxBalance(wallet3);
+    expect(
+      registerManyForClaims([entry(wallet1), entry(wallet3)], wallet3, SIGNER_MANAGER).result,
+    ).toBeOk(Cl.uint(1));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet3),
+    );
+    expect(getRegistration(wallet3, SIGNER_MANAGER)).toBeNone();
+    expect(before - stxBalance(wallet3)).toBe(FEE_PER_CLAIM);
+  });
+
+  it("skips entries whose fee is too small without aborting the batch", () => {
+    expect(
+      registerManyForClaims(
+        [entry(wallet1), entry(wallet2, FEE_PER_CLAIM - 1n)],
+        wallet3,
+        SIGNER_MANAGER,
+      ).result,
+    ).toBeOk(Cl.uint(1));
+    expect(getRegistration(wallet1, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet3),
+    );
+    expect(getRegistration(wallet2, SIGNER_MANAGER)).toBeNone();
+  });
+
+  it("registers 100 stakers in one call", () => {
+    const TOTAL = 100;
+    const stakers = Array.from({ length: TOTAL }, (_, i) => {
+      const hex = (BigInt(i) + 1n).toString(16).padStart(64, "0") + "01";
+      return privateKeyToAddress(hex, "testnet");
+    });
+
+    for (const staker of stakers) {
+      expect(
+        simnet.transferSTX(SIGNER_SET_MIN_USTX + 1_000_000n, staker, deployer).result,
+      ).toBeOk(Cl.bool(true));
+      stakeFor(staker, SIGNER_SET_MIN_USTX, 2n);
+    }
+
+    const before = stxBalance(wallet3);
+    const { result } = registerManyForClaims(
+      stakers.map((staker) => entry(staker)),
+      wallet3,
+      SIGNER_MANAGER,
+    );
+    expect(result).toBeOk(Cl.uint(TOTAL));
+    expect(before - stxBalance(wallet3)).toBe(BigInt(TOTAL) * FEE_PER_CLAIM);
+    expect(getRegistration(stakers[0]!, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet3),
+    );
+    expect(getRegistration(stakers[TOTAL - 1]!, SIGNER_MANAGER)).toBeSome(
+      stxRegistration(1n, STX_FIRST_CLAIM_DIST, FEE_PER_CLAIM, wallet3),
+    );
   });
 });
 


### PR DESCRIPTION
## Description

Closes https://github.com/stx-labs/spox/issues/78.

## Changes

* Add `register-many-for-claims` and `cancel-many-registrations`.
* Allow anyone to register anyone else. This is second best; we do it this way only because we can't determine on-chain whether the caller is an admin of the signer manager contract under the existing reference signer manager contract.
* Allow only the sponsor and the staker to cancel a registration, with funds going to the sponsor.
* Allow only the sponsor to `add-claims` to a registration.


## Testing Information

I added unit tests.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
